### PR TITLE
Fix QuickAccessCard text wrapping causing uneven card heights on narrow screens

### DIFF
--- a/app/src/main/java/com/voyagerfiles/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/voyagerfiles/ui/screens/HomeScreen.kt
@@ -414,6 +414,8 @@ private fun QuickAccessCard(
                 label,
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
             )
         }
     }


### PR DESCRIPTION
Before — /storage/emulated/0/Download (9 chars) wraps to two lines in the QuickAccessCard label on narrow screen widths, causing the Downloads card to become taller than its siblings (Pictures, Music, Videos) in the same row. After adding maxLines=1 with TextOverflow.Ellipsis, all four cards maintain equal height regardless of label text length.

 | Before                      | After                             |                                                                          
 |-----------------------------|-----------------------------------|                                                                          
 | <img width="1080" height="2400" alt="Screenshot_2026-06-18-21-16-05-460_com voyagerfiles" src="https://github.com/user-attachments/assets/ed6c75e4-d267-4c16-96cd-3c402c5a1f6f" /> | <img width="1080" height="2400" alt="Screenshot_2026-06-18-21-15-25-841_com voyagerfiles debug" src="https://github.com/user-attachments/assets/6341474c-01e5-45ea-946d-c625166feac8" /> |                                                                          
                                                                                                                                                  
     > This fix was AI-assisted (code generated by agent, reviewed and tested by human). 
