### PR TITLE
Add daily file actions and compact views

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ An open-source Android file manager for local storage, document trees, SFTP, FTP
 
 - Browse internal storage and mounted external volumes such as SD cards and USB/OTG media.
 - Continue without broad storage access and use Storage Access Framework document trees or remote servers in limited mode.
-- Switch between list and grid layouts, view image thumbnails, show hidden files, sort by name, size, date, or type, and search the current folder.
+- Switch among list, compact list, and grid layouts, view image thumbnails, show hidden files, sort by name, size, date, or type, and search the current folder.
 - Filter a folder by directories, images, videos, audio, documents, archives, or Android packages.
-- Select visible results, copy, move, rename, delete, and create files and folders, including cross-provider transfers.
-- Move local deletions to a recoverable per-volume Trash by default, restore items, or permanently delete them after confirmation.
+- Select visible results, share local or document-tree files, inspect file details, copy, move, rename, delete, and create files and folders, including cross-provider transfers.
+- Choose Trash or permanent deletion for each direct-local operation, restore recoverable per-volume Trash items, or disable Trash in Settings.
 - Bookmark local folders, open common media locations, and keep several local, document-tree, or remote browser sessions open.
 - Connect to SFTP, FTP, SMB, and WebDAV servers and download remote files or directories to Android's Downloads folder.
 - Authenticate to SFTP with a password, keyboard-interactive authentication, a private key file, or an in-app generated key pair.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,8 +28,8 @@ android {
         applicationId = "com.voyagerfiles"
         minSdk = 26
         targetSdk = 35
-        versionCode = 11
-        versionName = "1.3.0"
+        versionCode = 12
+        versionName = "1.4.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/androidTest/java/com/voyagerfiles/ui/components/FileDetailsSheetTest.kt
+++ b/app/src/androidTest/java/com/voyagerfiles/ui/components/FileDetailsSheetTest.kt
@@ -1,0 +1,45 @@
+package com.voyagerfiles.ui.components
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performScrollTo
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.voyagerfiles.data.model.FileItem
+import com.voyagerfiles.ui.theme.VoyagerTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class FileDetailsSheetTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun detailsShowsAvailableMetadata() {
+        composeTestRule.setContent {
+            VoyagerTheme {
+                FileDetailsSheet(
+                    file = FileItem(
+                        name = "report.pdf",
+                        path = "/storage/emulated/0/Documents/report.pdf",
+                        isDirectory = false,
+                        size = 2048,
+                        owner = "media_rw",
+                        permissions = "rw-r--r--",
+                    ),
+                    onDismiss = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Details").assertIsDisplayed()
+        composeTestRule.onNodeWithText("report.pdf").assertIsDisplayed()
+        composeTestRule.onNodeWithText("2 KB").assertIsDisplayed()
+        composeTestRule.onNodeWithText("/storage/emulated/0/Documents/report.pdf").assertIsDisplayed()
+        composeTestRule.onNodeWithText("media_rw").assertIsDisplayed()
+        composeTestRule.onNodeWithText("rw-r--r--").performScrollTo().assertIsDisplayed()
+    }
+}

--- a/app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserSelectionActionsTest.kt
+++ b/app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserSelectionActionsTest.kt
@@ -118,6 +118,20 @@ class BrowserSelectionActionsTest {
         }
     }
 
+    @Test
+    fun singleSelectionDetailsShowTheFilePath() {
+        val viewModel = launchBrowser()
+        waitForRoot(viewModel)
+
+        composeTestRule.onNode(hasText("notes.txt") and hasClickAction())
+            .performTouchInput { longClick() }
+        composeTestRule.onNodeWithContentDescription("More selection actions").performClick()
+        composeTestRule.onNodeWithText("Details").assertIsDisplayed().performClick()
+
+        composeTestRule.onNodeWithText("Details").assertIsDisplayed()
+        composeTestRule.onNodeWithText(root.resolve("notes.txt").absolutePath).assertIsDisplayed()
+    }
+
     private fun launchBrowser(): FileBrowserViewModel {
         val application = ApplicationProvider.getApplicationContext<Application>()
         val viewModel = FileBrowserViewModel(application)

--- a/app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserSelectionActionsTest.kt
+++ b/app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserSelectionActionsTest.kt
@@ -1,0 +1,80 @@
+package com.voyagerfiles.ui.screens
+
+import android.app.Application
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTouchInput
+import androidx.test.core.app.ApplicationProvider
+import com.voyagerfiles.viewmodel.FileBrowserViewModel
+import java.io.File
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class BrowserSelectionActionsTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var root: File
+
+    @Before
+    fun setUp() {
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        root = File(application.cacheDir, "browser-selection-actions-test").apply {
+            deleteRecursively()
+            mkdirs()
+            resolve("notes.txt").writeText("notes")
+            resolve("Folder").mkdirs()
+        }
+    }
+
+    @After
+    fun tearDown() {
+        root.deleteRecursively()
+    }
+
+    @Test
+    fun oneLocalFilePromotesShareRenameAndDelete() {
+        val viewModel = launchBrowser()
+        waitForRoot(viewModel)
+
+        composeTestRule.onNode(hasText("notes.txt") and hasClickAction())
+            .performTouchInput { longClick() }
+
+        composeTestRule.onNodeWithContentDescription("Share").assertExists()
+        composeTestRule.onNodeWithContentDescription("Rename").assertExists()
+        composeTestRule.onNodeWithContentDescription("Delete").assertExists()
+    }
+
+    private fun launchBrowser(): FileBrowserViewModel {
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        val viewModel = FileBrowserViewModel(application)
+        composeTestRule.setContent {
+            MaterialTheme {
+                BrowserScreen(
+                    viewModel = viewModel,
+                    onNavigateBack = {},
+                )
+            }
+        }
+        composeTestRule.runOnIdle {
+            viewModel.openLocalRoot(root.absolutePath)
+        }
+        return viewModel
+    }
+
+    private fun waitForRoot(viewModel: FileBrowserViewModel) {
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            viewModel.browseState.value.currentPath == root.absolutePath &&
+                !viewModel.browseState.value.isLoading
+        }
+        composeTestRule.onNodeWithText("notes.txt").assertExists()
+    }
+}

--- a/app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserSelectionActionsTest.kt
+++ b/app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserSelectionActionsTest.kt
@@ -4,10 +4,12 @@ import android.app.Application
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
 import androidx.test.core.app.ApplicationProvider
 import com.voyagerfiles.viewmodel.FileBrowserViewModel
@@ -51,6 +53,42 @@ class BrowserSelectionActionsTest {
         composeTestRule.onNodeWithContentDescription("Share").assertExists()
         composeTestRule.onNodeWithContentDescription("Rename").assertExists()
         composeTestRule.onNodeWithContentDescription("Delete").assertExists()
+    }
+
+    @Test
+    fun localDeleteOffersTrashAndPermanentChoices() {
+        val viewModel = launchBrowser()
+        composeTestRule.runOnIdle { viewModel.setUseTrash(true) }
+        waitForRoot(viewModel)
+        composeTestRule.waitUntil(timeoutMillis = 10_000) { viewModel.useTrash.value }
+
+        composeTestRule.onNode(hasText("notes.txt") and hasClickAction())
+            .performTouchInput { longClick() }
+        composeTestRule.onNodeWithContentDescription("Delete").performClick()
+
+        composeTestRule.onNodeWithText("Move to Trash").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Delete permanently").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Permanent deletion cannot be undone.", substring = true)
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText("Cancel").performClick()
+    }
+
+    @Test
+    fun permanentChoiceDeletesTheSelectedLocalFile() {
+        val viewModel = launchBrowser()
+        composeTestRule.runOnIdle { viewModel.setUseTrash(true) }
+        waitForRoot(viewModel)
+        composeTestRule.waitUntil(timeoutMillis = 10_000) { viewModel.useTrash.value }
+
+        composeTestRule.onNode(hasText("notes.txt") and hasClickAction())
+            .performTouchInput { longClick() }
+        composeTestRule.onNodeWithContentDescription("Delete").performClick()
+        composeTestRule.onNodeWithText("Delete permanently").performClick()
+
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            !root.resolve("notes.txt").exists()
+        }
+        composeTestRule.onNodeWithText("notes.txt").assertDoesNotExist()
     }
 
     private fun launchBrowser(): FileBrowserViewModel {

--- a/app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserSelectionActionsTest.kt
+++ b/app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserSelectionActionsTest.kt
@@ -12,8 +12,11 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
 import androidx.test.core.app.ApplicationProvider
+import com.voyagerfiles.data.local.PreferencesManager
+import com.voyagerfiles.data.model.ViewMode
 import com.voyagerfiles.viewmodel.FileBrowserViewModel
 import java.io.File
+import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -40,6 +43,8 @@ class BrowserSelectionActionsTest {
     @After
     fun tearDown() {
         root.deleteRecursively()
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        runBlocking { PreferencesManager(application).setViewMode(ViewMode.LIST) }
     }
 
     @Test
@@ -89,6 +94,28 @@ class BrowserSelectionActionsTest {
             !root.resolve("notes.txt").exists()
         }
         composeTestRule.onNodeWithText("notes.txt").assertDoesNotExist()
+    }
+
+    @Test
+    fun viewOptionsExposeAndPersistCompactList() {
+        val viewModel = launchBrowser()
+        waitForRoot(viewModel)
+        composeTestRule.runOnIdle { viewModel.setViewMode(ViewMode.LIST) }
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            viewModel.browseState.value.viewMode == ViewMode.LIST
+        }
+
+        composeTestRule.onNodeWithContentDescription("View options, current List").performClick()
+        composeTestRule.onNodeWithText("List").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Compact list").assertIsDisplayed().performClick()
+        composeTestRule.onNodeWithContentDescription("View options, current Compact list")
+            .assertIsDisplayed()
+
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        val restoredViewModel = FileBrowserViewModel(application)
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            restoredViewModel.browseState.value.viewMode == ViewMode.COMPACT
+        }
     }
 
     private fun launchBrowser(): FileBrowserViewModel {

--- a/app/src/androidTest/java/com/voyagerfiles/util/FileSharingTest.kt
+++ b/app/src/androidTest/java/com/voyagerfiles/util/FileSharingTest.kt
@@ -1,0 +1,72 @@
+package com.voyagerfiles.util
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.voyagerfiles.data.model.FileItem
+import com.voyagerfiles.data.model.FileSource
+import java.io.File
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class FileSharingTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val filesToDelete = mutableListOf<File>()
+
+    @After
+    fun cleanUp() {
+        filesToDelete.forEach(File::delete)
+    }
+
+    @Test
+    fun multipleLocalFilesBuildReadableSendMultipleIntent() {
+        val files = listOf(createLocalFile("one.jpg"), createLocalFile("two.png"))
+
+        val intent = FileUtils.createShareIntent(context, files).getOrThrow()
+
+        assertEquals(Intent.ACTION_SEND_MULTIPLE, intent.action)
+        assertEquals("image/*", intent.type)
+        assertTrue(intent.flags and Intent.FLAG_GRANT_READ_URI_PERMISSION != 0)
+        assertEquals(2, intent.clipData?.itemCount)
+        assertEquals(
+            2,
+            intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM, Uri::class.java)?.size,
+        )
+    }
+
+    @Test
+    fun safFileKeepsItsContentUri() {
+        val uri = Uri.parse("content://documents/tree/root/document/report.pdf")
+
+        val intent = FileUtils.createShareIntent(context, listOf(safFile(uri))).getOrThrow()
+
+        assertEquals(Intent.ACTION_SEND, intent.action)
+        assertEquals(uri, intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java))
+        assertEquals(uri, intent.clipData?.getItemAt(0)?.uri)
+    }
+
+    private fun createLocalFile(name: String): FileItem {
+        val file = File(context.cacheDir, name).apply { writeBytes(byteArrayOf(1, 2, 3)) }
+        filesToDelete += file
+        return FileItem(
+            name = file.name,
+            path = file.absolutePath,
+            isDirectory = false,
+            source = FileSource.LOCAL,
+        )
+    }
+
+    private fun safFile(uri: Uri) = FileItem(
+        name = "report.pdf",
+        path = uri.toString(),
+        isDirectory = false,
+        source = FileSource.SAF,
+    )
+}

--- a/app/src/main/java/com/voyagerfiles/data/model/FileItem.kt
+++ b/app/src/main/java/com/voyagerfiles/data/model/FileItem.kt
@@ -144,7 +144,8 @@ data class BrowseState(
         }
 }
 
-enum class ViewMode {
-    LIST,
-    GRID,
+enum class ViewMode(val label: String) {
+    LIST("List"),
+    COMPACT("Compact list"),
+    GRID("Grid"),
 }

--- a/app/src/main/java/com/voyagerfiles/ui/components/DeleteChoiceDialog.kt
+++ b/app/src/main/java/com/voyagerfiles/ui/components/DeleteChoiceDialog.kt
@@ -1,0 +1,48 @@
+package com.voyagerfiles.ui.components
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+
+data class DeleteChoiceDialogModel(
+    val title: String,
+    val message: String,
+    val trashLabel: String = "Move to Trash",
+    val permanentLabel: String = "Delete permanently",
+) {
+    companion object {
+        fun local(count: Int, fileName: String): DeleteChoiceDialogModel =
+            DeleteChoiceDialogModel(
+                title = if (count == 1) "Delete \"$fileName\"?" else "Delete $count items?",
+                message = "Move the selection to Trash so it can be restored later, or delete it permanently. Permanent deletion cannot be undone.",
+            )
+    }
+}
+
+@Composable
+fun DeleteChoiceDialog(
+    model: DeleteChoiceDialogModel,
+    onDismiss: () -> Unit,
+    onMoveToTrash: () -> Unit,
+    onDeletePermanently: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(model.title) },
+        text = { Text(model.message) },
+        confirmButton = {
+            TextButton(onClick = onMoveToTrash) { Text(model.trashLabel) }
+        },
+        dismissButton = {
+            Row {
+                TextButton(onClick = onDismiss) { Text("Cancel") }
+                TextButton(onClick = onDeletePermanently) {
+                    Text(model.permanentLabel, color = MaterialTheme.colorScheme.error)
+                }
+            }
+        },
+    )
+}

--- a/app/src/main/java/com/voyagerfiles/ui/components/FileDetailsSheet.kt
+++ b/app/src/main/java/com/voyagerfiles/ui/components/FileDetailsSheet.kt
@@ -1,0 +1,81 @@
+package com.voyagerfiles.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.voyagerfiles.data.model.FileItem
+import com.voyagerfiles.data.model.FileSource
+import java.text.DateFormat
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FileDetailsSheet(
+    file: FileItem,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val modified = remember(file.lastModified) {
+        DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT)
+            .format(file.lastModified)
+    }
+    val rows = buildList {
+        add("Name" to file.name)
+        add("Type" to if (file.isDirectory) "Folder" else file.mimeType)
+        if (!file.isDirectory) add("Size" to file.formattedSize)
+        add("Modified" to modified)
+        add("Source" to file.source.displayLabel)
+        add("Path" to file.path)
+        file.owner?.takeIf(String::isNotBlank)?.let { add("Owner" to it) }
+        file.permissions?.takeIf(String::isNotBlank)?.let { add("Permissions" to it) }
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        LazyColumn(
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(start = 24.dp, end = 24.dp, bottom = 32.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            item {
+                Text("Details", style = MaterialTheme.typography.headlineSmall)
+            }
+            items(rows, key = { it.first }) { (label, value) ->
+                Column {
+                    Text(
+                        text = label,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    SelectionContainer {
+                        Text(value, style = MaterialTheme.typography.bodyLarge)
+                    }
+                }
+            }
+        }
+    }
+}
+
+private val FileSource.displayLabel: String
+    get() = when (this) {
+        FileSource.LOCAL -> "Local storage"
+        FileSource.SAF -> "Document tree"
+        FileSource.SFTP -> "SFTP"
+        FileSource.FTP -> "FTP"
+        FileSource.SMB -> "SMB"
+        FileSource.WEBDAV -> "WebDAV"
+    }

--- a/app/src/main/java/com/voyagerfiles/ui/components/FileListItem.kt
+++ b/app/src/main/java/com/voyagerfiles/ui/components/FileListItem.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -36,6 +37,7 @@ fun FileListItem(
     onClick: () -> Unit,
     onLongClick: () -> Unit,
     modifier: Modifier = Modifier,
+    compact: Boolean = false,
 ) {
     val backgroundColor by animateColorAsState(
         targetValue = if (isSelected) {
@@ -45,6 +47,11 @@ fun FileListItem(
         },
         label = "selection_bg",
     )
+    val horizontalPadding = if (compact) 8.dp else 16.dp
+    val verticalPadding = if (compact) 4.dp else 12.dp
+    val iconSize = if (compact) 32.dp else 40.dp
+    val iconSpacing = if (compact) 12.dp else 16.dp
+    val nameStyle = if (compact) MaterialTheme.typography.bodyMedium else MaterialTheme.typography.bodyLarge
 
     Surface(
         color = backgroundColor,
@@ -57,7 +64,8 @@ fun FileListItem(
     ) {
         Row(
             modifier = Modifier
-                .padding(horizontal = 16.dp, vertical = 12.dp),
+                .heightIn(min = 48.dp)
+                .padding(horizontal = horizontalPadding, vertical = verticalPadding),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             if (isSelectionMode) {
@@ -71,9 +79,9 @@ fun FileListItem(
                 Spacer(modifier = Modifier.width(8.dp))
             }
 
-            FileThumbnailOrIcon(file = file, iconSize = 40.dp)
+            FileThumbnailOrIcon(file = file, iconSize = iconSize)
 
-            Spacer(modifier = Modifier.width(16.dp))
+            Spacer(modifier = Modifier.width(iconSpacing))
 
             Column(
                 modifier = Modifier.weight(1f),
@@ -81,7 +89,7 @@ fun FileListItem(
             ) {
                 Text(
                     text = file.name,
-                    style = MaterialTheme.typography.bodyLarge,
+                    style = nameStyle,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     color = MaterialTheme.colorScheme.onSurface,

--- a/app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt
+++ b/app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.SelectAll
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
@@ -101,6 +102,7 @@ import com.voyagerfiles.ui.components.FileListItem
 import com.voyagerfiles.ui.components.PathBreadcrumb
 import com.voyagerfiles.ui.components.RenameDialog
 import com.voyagerfiles.util.FileUtils
+import com.voyagerfiles.util.ShareIntentPlan
 import com.voyagerfiles.viewmodel.BrowserSession
 import com.voyagerfiles.viewmodel.ClipboardOperation
 import com.voyagerfiles.viewmodel.FileBrowserViewModel
@@ -138,12 +140,16 @@ fun BrowserScreen(
 
     val isSelectionMode = state.selectedFiles.isNotEmpty()
     val isNetwork = state.source.isNetwork
+    val selectedItems = remember(state.files, state.selectedFiles) {
+        state.files.filter { it.path in state.selectedFiles }
+    }
+    val sharePlan = remember(selectedItems) { ShareIntentPlan.forFiles(selectedItems) }
     val toolbarModel = remember(isNetwork) { BrowserToolbarModel.forState(isNetwork) }
-    val selectionToolbarModel = remember(isNetwork, state.selectedFiles.size) {
+    val selectionToolbarModel = remember(isNetwork, selectedItems.size, sharePlan) {
         SelectionToolbarModel.forState(
             isRemote = isNetwork,
-            selectionCount = state.selectedFiles.size,
-            canShare = false,
+            selectionCount = selectedItems.size,
+            canShare = sharePlan != null,
         )
     }
     val runningOperation = operationState as? OperationState.Running
@@ -169,6 +175,19 @@ fun BrowserScreen(
             showSessionsSheet = false
             onNavigateBack()
         }
+    }
+
+    fun shareSelected() {
+        FileUtils.shareFiles(context, selectedItems).fold(
+            onSuccess = { viewModel.clearSelection() },
+            onFailure = {
+                scope.launch {
+                    snackbarHostState.showSnackbar(
+                        "Could not share the selected files. Check that access is still available and try again."
+                    )
+                }
+            },
+        )
     }
 
     // Show snackbar messages from ViewModel
@@ -221,6 +240,14 @@ fun BrowserScreen(
                                 enabled = runningOperation == null,
                             ) {
                                 Icon(Icons.Filled.DriveFileRenameOutline, "Rename")
+                            }
+                        }
+                        if (SelectionToolbarAction.SHARE in selectionToolbarModel.primaryActions) {
+                            IconButton(
+                                onClick = ::shareSelected,
+                                enabled = runningOperation == null,
+                            ) {
+                                Icon(Icons.Filled.Share, "Share")
                             }
                         }
                         if (SelectionToolbarAction.DELETE in selectionToolbarModel.primaryActions) {

--- a/app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt
+++ b/app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material.icons.automirrored.filled.NoteAdd
 import androidx.compose.material.icons.automirrored.filled.Sort
 import androidx.compose.material.icons.automirrored.filled.ViewList
 import androidx.compose.material.icons.filled.BookmarkAdd
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.ContentCopy
@@ -50,6 +51,7 @@ import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.SelectAll
 import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.filled.ViewAgenda
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
@@ -136,6 +138,7 @@ fun BrowserScreen(
     var showDeleteDialog by remember { mutableStateOf(false) }
     var showRenameDialog by remember { mutableStateOf<String?>(null) }
     var showSortMenu by remember { mutableStateOf(false) }
+    var showViewMenu by remember { mutableStateOf(false) }
     var showMoreMenu by remember { mutableStateOf(false) }
     var showSelectionMoreMenu by remember { mutableStateOf(false) }
     var showCreateMenu by remember { mutableStateOf(false) }
@@ -355,16 +358,46 @@ fun BrowserScreen(
                             IconButton(onClick = { viewModel.refresh() }) {
                                 Icon(Icons.Filled.Refresh, "Refresh")
                             }
-                            IconButton(onClick = {
-                                viewModel.setViewMode(
-                                    if (state.viewMode == ViewMode.LIST) ViewMode.GRID else ViewMode.LIST
-                                )
-                            }) {
-                                Icon(
-                                    if (state.viewMode == ViewMode.LIST) Icons.Filled.GridView
-                                    else Icons.AutoMirrored.Filled.ViewList,
-                                    "Toggle view",
-                                )
+                            Box {
+                                IconButton(onClick = { showViewMenu = true }) {
+                                    Icon(
+                                        imageVector = when (state.viewMode) {
+                                            ViewMode.LIST -> Icons.AutoMirrored.Filled.ViewList
+                                            ViewMode.COMPACT -> Icons.Filled.ViewAgenda
+                                            ViewMode.GRID -> Icons.Filled.GridView
+                                        },
+                                        contentDescription = "View options, current ${state.viewMode.label}",
+                                    )
+                                }
+                                DropdownMenu(
+                                    expanded = showViewMenu,
+                                    onDismissRequest = { showViewMenu = false },
+                                ) {
+                                    ViewMode.entries.forEach { mode ->
+                                        DropdownMenuItem(
+                                            text = { Text(mode.label) },
+                                            leadingIcon = {
+                                                Icon(
+                                                    imageVector = when (mode) {
+                                                        ViewMode.LIST -> Icons.AutoMirrored.Filled.ViewList
+                                                        ViewMode.COMPACT -> Icons.Filled.ViewAgenda
+                                                        ViewMode.GRID -> Icons.Filled.GridView
+                                                    },
+                                                    contentDescription = null,
+                                                )
+                                            },
+                                            trailingIcon = {
+                                                if (state.viewMode == mode) {
+                                                    Icon(Icons.Filled.Check, contentDescription = "Selected")
+                                                }
+                                            },
+                                            onClick = {
+                                                viewModel.setViewMode(mode)
+                                                showViewMenu = false
+                                            },
+                                        )
+                                    }
+                                }
                             }
                             Box {
                                 IconButton(onClick = { showSortMenu = true }) {
@@ -641,13 +674,14 @@ fun BrowserScreen(
                     }
                 }
 
-                state.viewMode == ViewMode.LIST -> {
+                state.viewMode == ViewMode.LIST || state.viewMode == ViewMode.COMPACT -> {
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),
                     ) {
                         items(state.visibleFiles, key = { it.path }) { file ->
                             FileListItem(
                                 file = file,
+                                compact = state.viewMode == ViewMode.COMPACT,
                                 isSelected = file.path in state.selectedFiles,
                                 isSelectionMode = isSelectionMode,
                                 onClick = {
@@ -899,7 +933,7 @@ data class BrowserToolbarModel(
                 primaryActions = listOf(
                     BrowserToolbarAction.SESSIONS,
                     BrowserToolbarAction.REFRESH,
-                    BrowserToolbarAction.TOGGLE_VIEW,
+                    BrowserToolbarAction.VIEW_OPTIONS,
                     BrowserToolbarAction.SORT,
                 ),
                 overflowActions = if (isRemote) {
@@ -914,7 +948,7 @@ data class BrowserToolbarModel(
 enum class BrowserToolbarAction {
     SESSIONS,
     REFRESH,
-    TOGGLE_VIEW,
+    VIEW_OPTIONS,
     SORT,
     DISCONNECT,
 }

--- a/app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt
+++ b/app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt
@@ -140,7 +140,11 @@ fun BrowserScreen(
     val isNetwork = state.source.isNetwork
     val toolbarModel = remember(isNetwork) { BrowserToolbarModel.forState(isNetwork) }
     val selectionToolbarModel = remember(isNetwork, state.selectedFiles.size) {
-        SelectionToolbarModel.forState(isNetwork, state.selectedFiles.size)
+        SelectionToolbarModel.forState(
+            isRemote = isNetwork,
+            selectionCount = state.selectedFiles.size,
+            canShare = false,
+        )
     }
     val runningOperation = operationState as? OperationState.Running
 
@@ -211,6 +215,14 @@ fun BrowserScreen(
                                 Icon(Icons.Filled.ContentCut, "Cut")
                             }
                         }
+                        if (SelectionToolbarAction.RENAME in selectionToolbarModel.primaryActions) {
+                            IconButton(
+                                onClick = { showRenameDialog = state.selectedFiles.single() },
+                                enabled = runningOperation == null,
+                            ) {
+                                Icon(Icons.Filled.DriveFileRenameOutline, "Rename")
+                            }
+                        }
                         if (SelectionToolbarAction.DELETE in selectionToolbarModel.primaryActions) {
                             IconButton(
                                 onClick = { showDeleteDialog = true },
@@ -230,6 +242,26 @@ fun BrowserScreen(
                                 expanded = showSelectionMoreMenu,
                                 onDismissRequest = { showSelectionMoreMenu = false },
                             ) {
+                                if (SelectionToolbarAction.COPY in selectionToolbarModel.overflowActions) {
+                                    DropdownMenuItem(
+                                        text = { Text("Copy") },
+                                        leadingIcon = { Icon(Icons.Filled.ContentCopy, null) },
+                                        onClick = {
+                                            viewModel.copyToClipboard(state.selectedFiles.toList())
+                                            showSelectionMoreMenu = false
+                                        },
+                                    )
+                                }
+                                if (SelectionToolbarAction.CUT in selectionToolbarModel.overflowActions) {
+                                    DropdownMenuItem(
+                                        text = { Text("Cut") },
+                                        leadingIcon = { Icon(Icons.Filled.ContentCut, null) },
+                                        onClick = {
+                                            viewModel.cutToClipboard(state.selectedFiles.toList())
+                                            showSelectionMoreMenu = false
+                                        },
+                                    )
+                                }
                                 if (SelectionToolbarAction.SELECT_ALL in selectionToolbarModel.overflowActions) {
                                     DropdownMenuItem(
                                         text = { Text("Select all visible") },
@@ -851,19 +883,46 @@ data class SelectionToolbarModel(
     val overflowActions: List<SelectionToolbarAction>,
 ) {
     companion object {
-        fun forState(isRemote: Boolean, selectionCount: Int): SelectionToolbarModel =
-            SelectionToolbarModel(
-                primaryActions = listOf(
-                    SelectionToolbarAction.COPY,
-                    SelectionToolbarAction.CUT,
+        fun forState(
+            isRemote: Boolean,
+            selectionCount: Int,
+            canShare: Boolean,
+        ): SelectionToolbarModel {
+            val isSingle = selectionCount == 1
+            val primaryActions = when {
+                isSingle && canShare -> listOf(
+                    SelectionToolbarAction.SHARE,
+                    SelectionToolbarAction.RENAME,
                     SelectionToolbarAction.DELETE,
-                ),
+                )
+                isSingle -> listOf(
+                    SelectionToolbarAction.COPY,
+                    SelectionToolbarAction.RENAME,
+                    SelectionToolbarAction.DELETE,
+                )
+                canShare -> listOf(
+                    SelectionToolbarAction.COPY,
+                    SelectionToolbarAction.SHARE,
+                    SelectionToolbarAction.DELETE,
+                )
+                else -> listOf(
+                    SelectionToolbarAction.COPY,
+                    SelectionToolbarAction.DELETE,
+                )
+            }
+            return SelectionToolbarModel(
+                primaryActions = primaryActions,
                 overflowActions = buildList {
+                    if (SelectionToolbarAction.COPY !in primaryActions) {
+                        add(SelectionToolbarAction.COPY)
+                    }
+                    add(SelectionToolbarAction.CUT)
                     add(SelectionToolbarAction.SELECT_ALL)
                     if (isRemote) add(SelectionToolbarAction.DOWNLOAD)
-                    if (selectionCount == 1) add(SelectionToolbarAction.RENAME)
+                    if (isSingle) add(SelectionToolbarAction.DETAILS)
                 },
             )
+        }
     }
 }
 
@@ -874,6 +933,8 @@ enum class SelectionToolbarAction {
     SELECT_ALL,
     DOWNLOAD,
     RENAME,
+    SHARE,
+    DETAILS,
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt
+++ b/app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt
@@ -95,6 +95,8 @@ import com.voyagerfiles.data.model.SortBy
 import com.voyagerfiles.data.model.SortOrder
 import com.voyagerfiles.data.model.ViewMode
 import com.voyagerfiles.ui.components.CreateItemDialog
+import com.voyagerfiles.ui.components.DeleteChoiceDialog
+import com.voyagerfiles.ui.components.DeleteChoiceDialogModel
 import com.voyagerfiles.ui.components.DeleteConfirmDialog
 import com.voyagerfiles.ui.components.DeleteDialogModel
 import com.voyagerfiles.ui.components.FileGridItem
@@ -105,6 +107,7 @@ import com.voyagerfiles.util.FileUtils
 import com.voyagerfiles.util.ShareIntentPlan
 import com.voyagerfiles.viewmodel.BrowserSession
 import com.voyagerfiles.viewmodel.ClipboardOperation
+import com.voyagerfiles.viewmodel.DeleteMode
 import com.voyagerfiles.viewmodel.FileBrowserViewModel
 import com.voyagerfiles.viewmodel.OperationState
 import kotlinx.coroutines.launch
@@ -756,18 +759,29 @@ fun BrowserScreen(
     if (showDeleteDialog) {
         val count = state.selectedFiles.size
         val fileName = state.selectedFiles.firstOrNull()?.substringAfterLast("/") ?: ""
-        DeleteConfirmDialog(
-            model = if (state.source == FileSource.LOCAL && useTrash) {
-                DeleteDialogModel.localTrash(count, fileName)
-            } else {
-                DeleteDialogModel.permanent(count, fileName)
-            },
-            onDismiss = { showDeleteDialog = false },
-            onConfirm = {
-                viewModel.deleteSelected()
-                showDeleteDialog = false
-            },
-        )
+        if (state.source == FileSource.LOCAL && useTrash) {
+            DeleteChoiceDialog(
+                model = DeleteChoiceDialogModel.local(count, fileName),
+                onDismiss = { showDeleteDialog = false },
+                onMoveToTrash = {
+                    showDeleteDialog = false
+                    viewModel.deleteSelected(DeleteMode.TRASH)
+                },
+                onDeletePermanently = {
+                    showDeleteDialog = false
+                    viewModel.deleteSelected(DeleteMode.PERMANENT)
+                },
+            )
+        } else {
+            DeleteConfirmDialog(
+                model = DeleteDialogModel.permanent(count, fileName),
+                onDismiss = { showDeleteDialog = false },
+                onConfirm = {
+                    showDeleteDialog = false
+                    viewModel.deleteSelected(DeleteMode.PERMANENT)
+                },
+            )
+        }
     }
 
     showRenameDialog?.let { path ->

--- a/app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt
+++ b/app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.FolderOpen
 import androidx.compose.material.icons.filled.GridView
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.MoreVert
@@ -90,6 +91,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.voyagerfiles.data.model.FileItem
 import com.voyagerfiles.data.model.FileSource
 import com.voyagerfiles.data.model.FileTypeFilter
 import com.voyagerfiles.data.model.isNetwork
@@ -101,6 +103,7 @@ import com.voyagerfiles.ui.components.DeleteChoiceDialog
 import com.voyagerfiles.ui.components.DeleteChoiceDialogModel
 import com.voyagerfiles.ui.components.DeleteConfirmDialog
 import com.voyagerfiles.ui.components.DeleteDialogModel
+import com.voyagerfiles.ui.components.FileDetailsSheet
 import com.voyagerfiles.ui.components.FileGridItem
 import com.voyagerfiles.ui.components.FileListItem
 import com.voyagerfiles.ui.components.PathBreadcrumb
@@ -137,6 +140,7 @@ fun BrowserScreen(
     var showCreateFileDialog by remember { mutableStateOf(false) }
     var showDeleteDialog by remember { mutableStateOf(false) }
     var showRenameDialog by remember { mutableStateOf<String?>(null) }
+    var showDetailsFor by remember { mutableStateOf<FileItem?>(null) }
     var showSortMenu by remember { mutableStateOf(false) }
     var showViewMenu by remember { mutableStateOf(false) }
     var showMoreMenu by remember { mutableStateOf(false) }
@@ -321,6 +325,16 @@ fun BrowserScreen(
                                         leadingIcon = { Icon(Icons.Filled.DriveFileRenameOutline, null) },
                                         onClick = {
                                             showRenameDialog = state.selectedFiles.first()
+                                            showSelectionMoreMenu = false
+                                        },
+                                    )
+                                }
+                                if (SelectionToolbarAction.DETAILS in selectionToolbarModel.overflowActions) {
+                                    DropdownMenuItem(
+                                        text = { Text("Details") },
+                                        leadingIcon = { Icon(Icons.Filled.Info, null) },
+                                        onClick = {
+                                            showDetailsFor = selectedItems.singleOrNull()
                                             showSelectionMoreMenu = false
                                         },
                                     )
@@ -764,6 +778,13 @@ fun BrowserScreen(
             },
             onClose = { sessionId -> closeSession(sessionId) },
             onDismiss = { showSessionsSheet = false },
+        )
+    }
+
+    showDetailsFor?.let { file ->
+        FileDetailsSheet(
+            file = file,
+            onDismiss = { showDetailsFor = null },
         )
     }
 

--- a/app/src/main/java/com/voyagerfiles/util/FileUtils.kt
+++ b/app/src/main/java/com/voyagerfiles/util/FileUtils.kt
@@ -1,5 +1,7 @@
 package com.voyagerfiles.util
 
+import android.app.Activity
+import android.content.ClipData
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -134,19 +136,54 @@ object FileUtils {
     }
 
     fun shareFile(context: Context, file: FileItem) {
-        val javaFile = File(file.path)
-        val uri: Uri = FileProvider.getUriForFile(
-            context,
-            "${context.packageName}.fileprovider",
-            javaFile,
-        )
-        val intent = Intent(Intent.ACTION_SEND).apply {
-            type = file.mimeType
-            putExtra(Intent.EXTRA_STREAM, uri)
-            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-        }
-        context.startActivity(Intent.createChooser(intent, "Share"))
+        shareFiles(context, listOf(file)).getOrThrow()
     }
+
+    fun createShareIntent(context: Context, files: List<FileItem>): Result<Intent> = runCatching {
+        val plan = requireNotNull(ShareIntentPlan.forFiles(files)) {
+            "Select files stored on this device to share"
+        }
+        val uris = files.map { file ->
+            if (file.source == FileSource.SAF) {
+                Uri.parse(file.path)
+            } else {
+                FileProvider.getUriForFile(
+                    context,
+                    "${context.packageName}.fileprovider",
+                    File(file.path),
+                )
+            }
+        }
+        Intent(
+            if (plan.kind == ShareIntentKind.SINGLE) {
+                Intent.ACTION_SEND
+            } else {
+                Intent.ACTION_SEND_MULTIPLE
+            }
+        ).apply {
+            type = plan.mimeType
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            clipData = ClipData.newUri(
+                context.contentResolver,
+                files.first().name,
+                uris.first(),
+            ).also { clip ->
+                uris.drop(1).forEach { clip.addItem(ClipData.Item(it)) }
+            }
+            if (plan.kind == ShareIntentKind.SINGLE) {
+                putExtra(Intent.EXTRA_STREAM, uris.single())
+            } else {
+                putParcelableArrayListExtra(Intent.EXTRA_STREAM, ArrayList(uris))
+            }
+        }
+    }
+
+    fun shareFiles(context: Context, files: List<FileItem>): Result<Unit> =
+        createShareIntent(context, files).mapCatching { intent ->
+            val chooser = Intent.createChooser(intent, "Share")
+            if (context !is Activity) chooser.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            context.startActivity(chooser)
+        }
 
     private fun discoverStorageRoots(primaryPath: String): List<String> =
         runCatching {

--- a/app/src/main/java/com/voyagerfiles/util/ShareIntentPlan.kt
+++ b/app/src/main/java/com/voyagerfiles/util/ShareIntentPlan.kt
@@ -1,0 +1,35 @@
+package com.voyagerfiles.util
+
+import com.voyagerfiles.data.model.FileItem
+import com.voyagerfiles.data.model.FileSource
+
+enum class ShareIntentKind {
+    SINGLE,
+    MULTIPLE,
+}
+
+data class ShareIntentPlan(
+    val kind: ShareIntentKind,
+    val mimeType: String,
+) {
+    companion object {
+        fun forFiles(files: List<FileItem>): ShareIntentPlan? {
+            if (files.isEmpty()) return null
+            if (files.any { it.isDirectory || it.source !in shareableSources }) return null
+
+            val mimeTypes = files.map(FileItem::mimeType).distinct()
+            val topLevelTypes = mimeTypes.map { it.substringBefore('/') }.distinct()
+            val mimeType = when {
+                mimeTypes.size == 1 -> mimeTypes.single()
+                topLevelTypes.size == 1 -> "${topLevelTypes.single()}/*"
+                else -> "*/*"
+            }
+            return ShareIntentPlan(
+                kind = if (files.size == 1) ShareIntentKind.SINGLE else ShareIntentKind.MULTIPLE,
+                mimeType = mimeType,
+            )
+        }
+
+        private val shareableSources = setOf(FileSource.LOCAL, FileSource.SAF)
+    }
+}

--- a/app/src/main/java/com/voyagerfiles/viewmodel/DeleteMode.kt
+++ b/app/src/main/java/com/voyagerfiles/viewmodel/DeleteMode.kt
@@ -1,0 +1,6 @@
+package com.voyagerfiles.viewmodel
+
+enum class DeleteMode {
+    TRASH,
+    PERMANENT,
+}

--- a/app/src/main/java/com/voyagerfiles/viewmodel/FileBrowserViewModel.kt
+++ b/app/src/main/java/com/voyagerfiles/viewmodel/FileBrowserViewModel.kt
@@ -353,11 +353,20 @@ class FileBrowserViewModel(application: Application) : AndroidViewModel(applicat
         }
     }
 
-    fun deleteSelected() {
+    fun deleteSelected(mode: DeleteMode? = null) {
         val state = _browseState.value
         val selectedPaths = state.selectedFiles.toList()
         if (selectedPaths.isEmpty()) return
-        val moveToTrash = state.source == FileSource.LOCAL && useTrash.value
+        val resolvedMode = mode ?: if (state.source == FileSource.LOCAL && useTrash.value) {
+            DeleteMode.TRASH
+        } else {
+            DeleteMode.PERMANENT
+        }
+        if (resolvedMode == DeleteMode.TRASH && state.source != FileSource.LOCAL) {
+            showSnackbar("Trash is available only for direct local storage")
+            return
+        }
+        val moveToTrash = resolvedMode == DeleteMode.TRASH
         val provider = fileProvider
         launchOperation(if (moveToTrash) "Moving to Trash" else "Deleting") {
             val count = selectedPaths.size

--- a/app/src/test/java/com/voyagerfiles/ui/components/DeleteChoiceDialogModelTest.kt
+++ b/app/src/test/java/com/voyagerfiles/ui/components/DeleteChoiceDialogModelTest.kt
@@ -1,0 +1,24 @@
+package com.voyagerfiles.ui.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DeleteChoiceDialogModelTest {
+
+    @Test
+    fun singleItemNamesBothOutcomesAndIrreversibility() {
+        val model = DeleteChoiceDialogModel.local(1, "notes.txt")
+
+        assertEquals("Delete \"notes.txt\"?", model.title)
+        assertTrue(model.message.contains("restore"))
+        assertTrue(model.message.contains("cannot be undone"))
+        assertEquals("Move to Trash", model.trashLabel)
+        assertEquals("Delete permanently", model.permanentLabel)
+    }
+
+    @Test
+    fun multipleItemsUseTheSelectionCount() {
+        assertEquals("Delete 3 items?", DeleteChoiceDialogModel.local(3, "").title)
+    }
+}

--- a/app/src/test/java/com/voyagerfiles/ui/screens/BrowserToolbarModelTest.kt
+++ b/app/src/test/java/com/voyagerfiles/ui/screens/BrowserToolbarModelTest.kt
@@ -1,5 +1,6 @@
 package com.voyagerfiles.ui.screens
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -24,21 +25,67 @@ class BrowserToolbarModelTest {
 
     @Test
     fun selectionToolbarKeepsOnlyCoreDestructiveActionsVisible() {
-        val model = SelectionToolbarModel.forState(isRemote = false, selectionCount = 3)
+        val model = SelectionToolbarModel.forState(
+            isRemote = false,
+            selectionCount = 3,
+            canShare = false,
+        )
 
         assertTrue(model.primaryActions.contains(SelectionToolbarAction.COPY))
-        assertTrue(model.primaryActions.contains(SelectionToolbarAction.CUT))
         assertTrue(model.primaryActions.contains(SelectionToolbarAction.DELETE))
         assertTrue(model.primaryActions.size <= 3)
+        assertTrue(model.overflowActions.contains(SelectionToolbarAction.CUT))
         assertTrue(model.overflowActions.contains(SelectionToolbarAction.SELECT_ALL))
         assertFalse(model.overflowActions.contains(SelectionToolbarAction.RENAME))
     }
 
     @Test
-    fun remoteSingleSelectionExposesDownloadAndRenameInOverflow() {
-        val model = SelectionToolbarModel.forState(isRemote = true, selectionCount = 1)
+    fun remoteSingleSelectionExposesDownloadAndPrimaryRename() {
+        val model = SelectionToolbarModel.forState(
+            isRemote = true,
+            selectionCount = 1,
+            canShare = false,
+        )
 
         assertTrue(model.overflowActions.contains(SelectionToolbarAction.DOWNLOAD))
-        assertTrue(model.overflowActions.contains(SelectionToolbarAction.RENAME))
+        assertTrue(model.primaryActions.contains(SelectionToolbarAction.RENAME))
+    }
+
+    @Test
+    fun shareableSingleSelectionPromotesShareRenameAndDelete() {
+        val model = SelectionToolbarModel.forState(
+            isRemote = false,
+            selectionCount = 1,
+            canShare = true,
+        )
+
+        assertEquals(
+            listOf(
+                SelectionToolbarAction.SHARE,
+                SelectionToolbarAction.RENAME,
+                SelectionToolbarAction.DELETE,
+            ),
+            model.primaryActions,
+        )
+        assertTrue(model.overflowActions.contains(SelectionToolbarAction.COPY))
+        assertTrue(model.overflowActions.contains(SelectionToolbarAction.CUT))
+        assertTrue(model.overflowActions.contains(SelectionToolbarAction.DETAILS))
+    }
+
+    @Test
+    fun multipleRemoteSelectionKeepsShareAndRenameHidden() {
+        val model = SelectionToolbarModel.forState(
+            isRemote = true,
+            selectionCount = 2,
+            canShare = false,
+        )
+
+        assertEquals(
+            listOf(SelectionToolbarAction.COPY, SelectionToolbarAction.DELETE),
+            model.primaryActions,
+        )
+        assertFalse(model.primaryActions.contains(SelectionToolbarAction.SHARE))
+        assertFalse(model.overflowActions.contains(SelectionToolbarAction.RENAME))
+        assertTrue(model.overflowActions.contains(SelectionToolbarAction.DOWNLOAD))
     }
 }

--- a/app/src/test/java/com/voyagerfiles/ui/screens/BrowserToolbarModelTest.kt
+++ b/app/src/test/java/com/voyagerfiles/ui/screens/BrowserToolbarModelTest.kt
@@ -1,11 +1,19 @@
 package com.voyagerfiles.ui.screens
 
+import com.voyagerfiles.data.model.ViewMode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class BrowserToolbarModelTest {
+
+    @Test
+    fun viewModesHaveUserFacingLabels() {
+        assertEquals("List", ViewMode.LIST.label)
+        assertEquals("Compact list", ViewMode.COMPACT.label)
+        assertEquals("Grid", ViewMode.GRID.label)
+    }
 
     @Test
     fun remoteToolbarMovesDisconnectToOverflow() {

--- a/app/src/test/java/com/voyagerfiles/util/ShareIntentPlanTest.kt
+++ b/app/src/test/java/com/voyagerfiles/util/ShareIntentPlanTest.kt
@@ -1,0 +1,62 @@
+package com.voyagerfiles.util
+
+import com.voyagerfiles.data.model.FileItem
+import com.voyagerfiles.data.model.FileSource
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ShareIntentPlanTest {
+
+    @Test
+    fun plansSingleAndMultipleShares() {
+        assertEquals(
+            ShareIntentPlan(ShareIntentKind.SINGLE, "image/jpeg"),
+            ShareIntentPlan.forFiles(listOf(localFile("one.jpg"))),
+        )
+        assertEquals(
+            ShareIntentPlan(ShareIntentKind.MULTIPLE, "image/*"),
+            ShareIntentPlan.forFiles(listOf(localFile("one.jpg"), localFile("two.png"))),
+        )
+    }
+
+    @Test
+    fun rejectsDirectoriesAndRemoteFiles() {
+        assertNull(ShareIntentPlan.forFiles(listOf(localDirectory("Folder"))))
+        assertNull(ShareIntentPlan.forFiles(listOf(remoteFile("report.pdf"))))
+    }
+
+    @Test
+    fun rejectsAnEmptySelection() {
+        assertNull(ShareIntentPlan.forFiles(emptyList()))
+    }
+
+    @Test
+    fun unrelatedMimeFamiliesUseWildcard() {
+        assertEquals(
+            "*/*",
+            ShareIntentPlan.forFiles(listOf(localFile("one.jpg"), localFile("notes.txt")))?.mimeType,
+        )
+    }
+
+    private fun localFile(name: String) = FileItem(
+        name = name,
+        path = "/storage/emulated/0/$name",
+        isDirectory = false,
+        source = FileSource.LOCAL,
+    )
+
+    private fun localDirectory(name: String) = FileItem(
+        name = name,
+        path = "/storage/emulated/0/$name",
+        isDirectory = true,
+        source = FileSource.LOCAL,
+    )
+
+    private fun remoteFile(name: String) = FileItem(
+        name = name,
+        path = "/$name",
+        isDirectory = false,
+        source = FileSource.SFTP,
+    )
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,9 +4,9 @@ Voyager is a single-activity Jetpack Compose application. `MainActivity` owns th
 
 ## UI and navigation
 
-`AppNavigation` defines Home, Browser, Remote Connections, Trash, and Settings destinations. Home presents storage volumes, common folders, local bookmarks, document-tree access, active sessions, Trash, and remote connections. Browser renders a session-aware toolbar, breadcrumb navigation, search and type filters, list or grid content, selection actions, progress, empty states, and retryable errors.
+`AppNavigation` defines Home, Browser, Remote Connections, Trash, and Settings destinations. Home presents storage volumes, common folders, local bookmarks, document-tree access, active sessions, Trash, and remote connections. Browser renders a session-aware toolbar, breadcrumb navigation, search and type filters, list, compact-list, or grid content, contextual selection actions, progress, empty states, retryable errors, and a read-only details sheet.
 
-The UI uses Material 3 components and theme tokens from `ui/theme`. Destructive file deletion, permanent Trash deletion, emptying Trash, deleting saved connections, and saving a cleartext remote transport require explicit confirmation where appropriate.
+The UI uses Material 3 components and theme tokens from `ui/theme`. Direct-local deletion offers recoverable Trash and explicitly irreversible permanent deletion per operation. Permanent-only provider deletion, permanent Trash deletion, emptying Trash, deleting saved connections, and saving a cleartext remote transport require explicit confirmation where appropriate.
 
 ## Browser state and sessions
 
@@ -29,6 +29,8 @@ All storage backends implement `FileProvider`, which defines listing, metadata, 
 
 `FileOperationCoordinator` handles copy and move across different providers. It rejects destination conflicts, copies recursively, removes a newly created partial destination after failure, and deletes a move source only after the copy succeeds. Providers handle same-provider operations so they can use native rename or server-side copy behavior when available.
 
+Android sharing is intentionally limited to local and SAF files in the current implementation. `ShareIntentPlan` rejects directories and remote items, computes the narrowest common MIME type, and chooses `ACTION_SEND` or `ACTION_SEND_MULTIPLE`. `FileUtils` exposes local files through the app `FileProvider`, preserves SAF content URIs, grants read access through both the intent flag and `ClipData`, and opens the system chooser.
+
 ## Storage access
 
 On Android 11 and later, full local browsing uses `MANAGE_EXTERNAL_STORAGE`. A user who declines can explicitly enter limited mode, where SAF document trees and remote connections remain available. On older supported versions, Voyager requests legacy read and write storage permissions.
@@ -37,7 +39,7 @@ On Android 11 and later, full local browsing uses `MANAGE_EXTERNAL_STORAGE`. A u
 
 ## Trash
 
-Local deletion uses `LocalTrashManager` by default. Each configured volume has a hidden `.VoyagerTrash` directory containing one payload and metadata file per entry. A pending directory makes the move recoverable if finalization is interrupted. Restore recreates a missing parent directory but refuses to overwrite an existing destination. SAF and remote deletions remain permanent and use permanent-delete confirmation wording.
+Local deletion uses `LocalTrashManager` by default. Each configured volume has a hidden `.VoyagerTrash` directory containing one payload and metadata file per entry. A pending directory makes the move recoverable if finalization is interrupted. Restore recreates a missing parent directory but refuses to overwrite an existing destination. When Trash is enabled, direct-local deletion presents both Trash and permanent choices without mutating the saved preference. SAF and remote deletions remain permanent and use permanent-delete confirmation wording.
 
 ## Persistence and secrets
 
@@ -53,4 +55,4 @@ Filesystem and network work runs on `Dispatchers.IO`. `OperationState` serialize
 
 ## Tests
 
-JVM tests cover pure models, validation, operation safety, Trash recovery, credentials, storage adapters, navigation races, and embedded FTP, SFTP, and WebDAV servers. SMB integration tests run when server credentials are supplied through environment variables. Android instrumentation tests cover Compose rendering, unavailable storage, destructive confirmation, search-to-folder Back behavior, selection-control accessibility, and Android Keystore behavior. See [TESTING.md](TESTING.md) for commands and the manual regression matrix.
+JVM tests cover pure models, sharing plans, validation, operation safety, Trash recovery, credentials, storage adapters, navigation races, and embedded FTP, SFTP, and WebDAV servers. SMB integration tests run when server credentials are supplied through environment variables. Android instrumentation tests cover Compose rendering, unavailable storage, single and multiple share intents, contextual selection actions, per-operation deletion choices, compact-view persistence, file details, search-to-folder Back behavior, selection-control accessibility, and Android Keystore behavior. See [TESTING.md](TESTING.md) for commands and the manual regression matrix.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -33,7 +33,7 @@ adb connect 192.168.27.167:5555
 ANDROID_SERIAL=192.168.27.167:5555 ./gradlew connectedDebugAndroidTest --stacktrace
 ```
 
-Instrumentation installs the debug package `com.voyagerfiles.debug`. The current tests exercise thumbnail fallback rendering, unavailable-storage presentation, saved-connection delete confirmation, parent navigation after using search, selection-control accessibility labels, and Android Keystore encryption.
+Instrumentation installs the debug package `com.voyagerfiles.debug`. The current tests exercise thumbnail fallback rendering, unavailable-storage presentation, saved-connection and file-delete confirmations, single and multiple share intents, contextual selection actions, permanent local deletion, compact-view persistence, file details, parent navigation after using search, selection-control accessibility labels, and Android Keystore encryption.
 
 ## Protocol integration tests
 
@@ -63,11 +63,11 @@ Use disposable files and keep device orientation unlocked unless a case calls fo
 | Storage | Browse internal storage, an available removable volume, and an unavailable or unmounted volume if one is present. |
 | Navigation | Enter nested directories, use breadcrumbs and Back, switch sessions during a slow load, rotate the device, and confirm the latest location remains visible. |
 | Search and filters | Search case-insensitively, combine search with each type filter, select all visible results, clear filters, and test an empty result. |
-| File operations | Create, rename, copy, move, and delete files and directories; attempt a duplicate destination and a move into a descendant; verify the source survives failures. |
-| Trash | Move a local file to Trash, restore it, create a restore conflict, permanently delete an entry, empty Trash, and repeat with Trash disabled. |
+| File operations | Create, rename, copy, move, and delete files and directories; share one and several local or SAF files; inspect Details; attempt a duplicate destination and a move into a descendant; verify the source survives failures. |
+| Trash | For a direct-local selection, verify both Trash and permanent choices; move a file to Trash, restore it, create a restore conflict, permanently delete an entry, empty Trash, and repeat with Trash disabled. |
 | Error recovery | Remove or unmount a location while browsing, deny a SAF operation, open an unsupported file, use a bad remote hostname, and verify retry or actionable feedback. |
 | Remote | Verify SFTP first-use pinning and changed-key rejection, FTP cleartext confirmation, HTTPS WebDAV on a custom port, HTTP warning, large transfers, and a connection delete confirmation. |
-| Layout and accessibility | Test portrait and landscape, large font and display sizes, TalkBack labels, 48 dp touch targets, loading indicators, empty states, selection mode, dialogs, and keyboard focus where available. |
+| Layout and accessibility | Test portrait and landscape, large font and display sizes, List, Compact list, and Grid persistence, TalkBack labels, 48 dp touch targets, loading indicators, empty states, selection mode, view menus, details sheets, dialogs, and keyboard focus where available. |
 
 ## Useful device commands
 

--- a/docs/superpowers/plans/2026-07-14-daily-actions-sharing-view-implementation.md
+++ b/docs/superpowers/plans/2026-07-14-daily-actions-sharing-view-implementation.md
@@ -1014,7 +1014,7 @@ Expected: all JVM and device tests pass, lint has zero errors, and debug and rel
 
 - [ ] **Step 7: Review warnings, artifacts, and the final diff**
 
-Inspect the lint XML by warning ID, aggregate test XML counts, run `git diff --check`, confirm no fixture or audit file is tracked, confirm version 1.3.0 remains unchanged during feature work, and review every changed production file for error paths, selection state, and accessibility labels.
+Inspect the lint XML by warning ID, aggregate test XML counts, run `git diff --check`, confirm no fixture or audit file is tracked, confirm the release-only version change is consistently 1.4.0 with version code 12, and review every changed production file for error paths, selection state, and accessibility labels.
 
 - [ ] **Step 8: Remove device fixtures and restore user state**
 

--- a/docs/superpowers/plans/2026-07-14-daily-actions-sharing-view-implementation.md
+++ b/docs/superpowers/plans/2026-07-14-daily-actions-sharing-view-implementation.md
@@ -1,0 +1,1032 @@
+# Daily Actions, Sharing, and View Options Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Voyager's daily selected-item actions discoverable and safe by adding local and SAF sharing, a per-operation Trash choice, primary rename, compact list mode, explicit view options, and a file Details sheet.
+
+**Architecture:** Keep `BrowserScreen` and `FileBrowserViewModel` as the orchestration points, but place selection policy, share planning, delete copy, and file-detail presentation in focused testable models. Reuse the existing Material 3 components, `FileProvider` abstraction, `FileProvider` manifest entry, and DataStore view preference. Add no runtime dependency.
+
+**Tech Stack:** Kotlin 2.1, Android intents and `FileProvider`, Jetpack Compose Material 3, DataStore Preferences, JUnit 4, AndroidX Compose instrumentation tests.
+
+## Global Constraints
+
+- Preserve the existing Compose, Material 3, ViewModel, provider, Room, DataStore, navigation, and theme conventions.
+- Add no runtime dependency.
+- Every behavior change begins with a focused failing test and finishes with that focused test green.
+- Trash remains the safe default for direct local deletion when enabled.
+- Permanent deletion always requires confirmation and states that it cannot be undone.
+- Share only non-directory direct local or SAF items in this milestone.
+- Keep the selection top bar to at most three primary actions plus overflow on a narrow phone.
+- Keep every changed interactive target at least 48dp.
+- Keep prose paragraphs on one physical line and do not add AI-authorship markers.
+
+---
+
+### Task 1: Define context-aware selection action placement
+
+**Files:**
+- Modify: `app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt:117-274,843-879`
+- Modify: `app/src/test/java/com/voyagerfiles/ui/screens/BrowserToolbarModelTest.kt`
+
+**Interfaces:**
+- Produces: `SelectionToolbarModel.forState(isRemote: Boolean, selectionCount: Int, canShare: Boolean): SelectionToolbarModel`
+- Produces: `SelectionToolbarAction.SHARE` and `SelectionToolbarAction.DETAILS`
+- Consumes later: Tasks 2, 3, and 5 render the actions defined here.
+
+- [ ] **Step 1: Write failing action-placement tests**
+
+```kotlin
+@Test
+fun shareableSingleSelectionPromotesShareRenameAndDelete() {
+    val model = SelectionToolbarModel.forState(
+        isRemote = false,
+        selectionCount = 1,
+        canShare = true,
+    )
+
+    assertEquals(
+        listOf(
+            SelectionToolbarAction.SHARE,
+            SelectionToolbarAction.RENAME,
+            SelectionToolbarAction.DELETE,
+        ),
+        model.primaryActions,
+    )
+    assertTrue(model.overflowActions.contains(SelectionToolbarAction.COPY))
+    assertTrue(model.overflowActions.contains(SelectionToolbarAction.CUT))
+    assertTrue(model.overflowActions.contains(SelectionToolbarAction.DETAILS))
+}
+
+@Test
+fun multipleRemoteSelectionKeepsShareAndRenameHidden() {
+    val model = SelectionToolbarModel.forState(
+        isRemote = true,
+        selectionCount = 2,
+        canShare = false,
+    )
+
+    assertEquals(
+        listOf(SelectionToolbarAction.COPY, SelectionToolbarAction.DELETE),
+        model.primaryActions,
+    )
+    assertFalse(model.primaryActions.contains(SelectionToolbarAction.SHARE))
+    assertFalse(model.overflowActions.contains(SelectionToolbarAction.RENAME))
+    assertTrue(model.overflowActions.contains(SelectionToolbarAction.DOWNLOAD))
+}
+```
+
+- [ ] **Step 2: Run the focused model test and confirm RED**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.ui.screens.BrowserToolbarModelTest`
+
+Expected: compilation fails because the new signature and actions do not exist.
+
+- [ ] **Step 3: Implement the minimal selection policy**
+
+```kotlin
+fun forState(
+    isRemote: Boolean,
+    selectionCount: Int,
+    canShare: Boolean,
+): SelectionToolbarModel {
+    val isSingle = selectionCount == 1
+    val primary = when {
+        isSingle && canShare -> listOf(SelectionToolbarAction.SHARE, SelectionToolbarAction.RENAME, SelectionToolbarAction.DELETE)
+        isSingle -> listOf(SelectionToolbarAction.COPY, SelectionToolbarAction.RENAME, SelectionToolbarAction.DELETE)
+        canShare -> listOf(SelectionToolbarAction.COPY, SelectionToolbarAction.SHARE, SelectionToolbarAction.DELETE)
+        else -> listOf(SelectionToolbarAction.COPY, SelectionToolbarAction.DELETE)
+    }
+    val overflow = buildList {
+        if (SelectionToolbarAction.COPY !in primary) add(SelectionToolbarAction.COPY)
+        add(SelectionToolbarAction.CUT)
+        add(SelectionToolbarAction.SELECT_ALL)
+        if (isRemote) add(SelectionToolbarAction.DOWNLOAD)
+        if (isSingle) add(SelectionToolbarAction.DETAILS)
+    }
+    return SelectionToolbarModel(primary, overflow)
+}
+```
+
+- [ ] **Step 4: Run the focused model test and confirm GREEN**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.ui.screens.BrowserToolbarModelTest`
+
+Expected: all toolbar model tests pass and every primary-action list has no more than three entries.
+
+- [ ] **Step 5: Render primary Rename and overflow Copy and Cut**
+
+Call the new model with `canShare = false` until Task 2 supplies share eligibility. Render Rename in the primary bar when requested, and render Copy and Cut in overflow when the model moves them there.
+
+```kotlin
+val selectionToolbarModel = remember(isNetwork, state.selectedFiles.size) {
+    SelectionToolbarModel.forState(
+        isRemote = isNetwork,
+        selectionCount = state.selectedFiles.size,
+        canShare = false,
+    )
+}
+
+if (SelectionToolbarAction.RENAME in selectionToolbarModel.primaryActions) {
+    IconButton(
+        onClick = { showRenameDialog = state.selectedFiles.single() },
+        enabled = runningOperation == null,
+    ) {
+        Icon(Icons.Filled.DriveFileRenameOutline, "Rename")
+    }
+}
+
+if (SelectionToolbarAction.COPY in selectionToolbarModel.overflowActions) {
+    DropdownMenuItem(
+        text = { Text("Copy") },
+        leadingIcon = { Icon(Icons.Filled.ContentCopy, null) },
+        onClick = {
+            viewModel.copyToClipboard(state.selectedFiles.toList())
+            showSelectionMoreMenu = false
+        },
+    )
+}
+if (SelectionToolbarAction.CUT in selectionToolbarModel.overflowActions) {
+    DropdownMenuItem(
+        text = { Text("Cut") },
+        leadingIcon = { Icon(Icons.Filled.ContentCut, null) },
+        onClick = {
+            viewModel.cutToClipboard(state.selectedFiles.toList())
+            showSelectionMoreMenu = false
+        },
+    )
+}
+```
+
+- [ ] **Step 6: Commit the selection policy**
+
+```bash
+git add app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt app/src/test/java/com/voyagerfiles/ui/screens/BrowserToolbarModelTest.kt
+git commit -m "feat: prioritize daily selection actions"
+```
+
+### Task 2: Share eligible local and SAF files through Android
+
+**Files:**
+- Create: `app/src/main/java/com/voyagerfiles/util/ShareIntentPlan.kt`
+- Create: `app/src/test/java/com/voyagerfiles/util/ShareIntentPlanTest.kt`
+- Create: `app/src/androidTest/java/com/voyagerfiles/util/FileSharingTest.kt`
+- Modify: `app/src/main/java/com/voyagerfiles/util/FileUtils.kt:116-151`
+- Modify: `app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt:117-274`
+
+**Interfaces:**
+- Produces: `enum class ShareIntentKind { SINGLE, MULTIPLE }`
+- Produces: `data class ShareIntentPlan(val kind: ShareIntentKind, val mimeType: String)`
+- Produces: `ShareIntentPlan.forFiles(files: List<FileItem>): ShareIntentPlan?`
+- Produces: `FileUtils.createShareIntent(context: Context, files: List<FileItem>): Result<Intent>`
+- Produces: `FileUtils.shareFiles(context: Context, files: List<FileItem>): Result<Unit>`
+- Consumes: `SelectionToolbarAction.SHARE` from Task 1.
+
+- [ ] **Step 1: Write failing pure share-plan tests**
+
+```kotlin
+@Test
+fun plansSingleAndMultipleShares() {
+    assertEquals(
+        ShareIntentPlan(ShareIntentKind.SINGLE, "image/jpeg"),
+        ShareIntentPlan.forFiles(listOf(localFile("one.jpg"))),
+    )
+    assertEquals(
+        ShareIntentPlan(ShareIntentKind.MULTIPLE, "image/*"),
+        ShareIntentPlan.forFiles(listOf(localFile("one.jpg"), localFile("two.png"))),
+    )
+}
+
+@Test
+fun rejectsDirectoriesAndRemoteFiles() {
+    assertNull(ShareIntentPlan.forFiles(listOf(localDirectory("Folder"))))
+    assertNull(ShareIntentPlan.forFiles(listOf(remoteFile("report.pdf"))))
+}
+
+@Test
+fun unrelatedMimeFamiliesUseWildcard() {
+    assertEquals(
+        "*/*",
+        ShareIntentPlan.forFiles(listOf(localFile("one.jpg"), localFile("notes.txt")))?.mimeType,
+    )
+}
+
+private fun localFile(name: String) = FileItem(
+    name = name,
+    path = "/storage/emulated/0/$name",
+    isDirectory = false,
+    source = FileSource.LOCAL,
+)
+
+private fun localDirectory(name: String) = FileItem(
+    name = name,
+    path = "/storage/emulated/0/$name",
+    isDirectory = true,
+    source = FileSource.LOCAL,
+)
+
+private fun remoteFile(name: String) = FileItem(
+    name = name,
+    path = "/$name",
+    isDirectory = false,
+    source = FileSource.SFTP,
+)
+```
+
+- [ ] **Step 2: Run the pure tests and confirm RED**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.util.ShareIntentPlanTest`
+
+Expected: compilation fails because `ShareIntentPlan` does not exist.
+
+- [ ] **Step 3: Implement the pure share plan**
+
+```kotlin
+data class ShareIntentPlan(
+    val kind: ShareIntentKind,
+    val mimeType: String,
+) {
+    companion object {
+        fun forFiles(files: List<FileItem>): ShareIntentPlan? {
+            if (files.isEmpty()) return null
+            if (files.any { it.isDirectory || it.source !in setOf(FileSource.LOCAL, FileSource.SAF) }) return null
+            val mimeTypes = files.map(FileItem::mimeType).distinct()
+            val mimeType = when {
+                mimeTypes.size == 1 -> mimeTypes.single()
+                mimeTypes.map { it.substringBefore('/') }.distinct().size == 1 ->
+                    "${mimeTypes.first().substringBefore('/')}/*"
+                else -> "*/*"
+            }
+            return ShareIntentPlan(
+                kind = if (files.size == 1) ShareIntentKind.SINGLE else ShareIntentKind.MULTIPLE,
+                mimeType = mimeType,
+            )
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the pure tests and confirm GREEN**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.util.ShareIntentPlanTest`
+
+Expected: all share-plan tests pass.
+
+- [ ] **Step 5: Write failing Android intent tests**
+
+```kotlin
+@Test
+fun multipleLocalFilesBuildReadableSendMultipleIntent() {
+    val files = listOf(createLocalFile("one.jpg"), createLocalFile("two.png"))
+    val intent = FileUtils.createShareIntent(context, files).getOrThrow()
+
+    assertEquals(Intent.ACTION_SEND_MULTIPLE, intent.action)
+    assertEquals("image/*", intent.type)
+    assertTrue(intent.flags and Intent.FLAG_GRANT_READ_URI_PERMISSION != 0)
+    assertEquals(2, intent.clipData?.itemCount)
+    assertEquals(2, intent.getParcelableArrayListExtra<Uri>(Intent.EXTRA_STREAM)?.size)
+}
+
+@Test
+fun safFileKeepsItsContentUri() {
+    val uri = Uri.parse("content://documents/tree/root/document/report.pdf")
+    val intent = FileUtils.createShareIntent(context, listOf(safFile(uri))).getOrThrow()
+
+    assertEquals(uri, intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java))
+}
+
+private fun createLocalFile(name: String): FileItem {
+    val file = File(context.cacheDir, name).apply { writeBytes(byteArrayOf(1, 2, 3)) }
+    return FileItem(
+        name = file.name,
+        path = file.absolutePath,
+        isDirectory = false,
+        source = FileSource.LOCAL,
+    )
+}
+
+private fun safFile(uri: Uri) = FileItem(
+    name = "report.pdf",
+    path = uri.toString(),
+    isDirectory = false,
+    source = FileSource.SAF,
+)
+```
+
+- [ ] **Step 6: Run the Android intent test and confirm RED**
+
+Run: `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew connectedDebugAndroidTest --tests com.voyagerfiles.util.FileSharingTest`
+
+Expected: compilation fails because `createShareIntent` does not exist.
+
+- [ ] **Step 7: Build readable single and multiple share intents**
+
+```kotlin
+fun createShareIntent(context: Context, files: List<FileItem>): Result<Intent> = runCatching {
+    val plan = requireNotNull(ShareIntentPlan.forFiles(files)) { "Select files stored on this device to share" }
+    val uris = files.map { file ->
+        if (file.source == FileSource.SAF) Uri.parse(file.path)
+        else FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", File(file.path))
+    }
+    Intent(
+        if (plan.kind == ShareIntentKind.SINGLE) Intent.ACTION_SEND else Intent.ACTION_SEND_MULTIPLE,
+    ).apply {
+        type = plan.mimeType
+        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        clipData = ClipData.newUri(context.contentResolver, files.first().name, uris.first()).also { clip ->
+            uris.drop(1).forEach { clip.addItem(ClipData.Item(it)) }
+        }
+        if (plan.kind == ShareIntentKind.SINGLE) putExtra(Intent.EXTRA_STREAM, uris.single())
+        else putParcelableArrayListExtra(Intent.EXTRA_STREAM, ArrayList(uris))
+    }
+}
+
+fun shareFiles(context: Context, files: List<FileItem>): Result<Unit> =
+    createShareIntent(context, files).mapCatching { intent ->
+        context.startActivity(Intent.createChooser(intent, "Share"))
+    }
+```
+
+- [ ] **Step 8: Run JVM and Android share tests and confirm GREEN**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.util.ShareIntentPlanTest`
+
+Run: `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew connectedDebugAndroidTest --tests com.voyagerfiles.util.FileSharingTest`
+
+Expected: both focused suites pass.
+
+- [ ] **Step 9: Wire Share into selection mode**
+
+Build `selectedItems` from the current directory listing, derive `canShare` through `ShareIntentPlan.forFiles(selectedItems) != null`, render Share wherever the Task 1 model requests it, and clear selection only after `FileUtils.shareFiles` succeeds.
+
+```kotlin
+val selectedItems = remember(state.files, state.selectedFiles) {
+    state.files.filter { it.path in state.selectedFiles }
+}
+val sharePlan = remember(selectedItems) { ShareIntentPlan.forFiles(selectedItems) }
+val selectionToolbarModel = remember(isNetwork, selectedItems.size, sharePlan) {
+    SelectionToolbarModel.forState(
+        isRemote = isNetwork,
+        selectionCount = selectedItems.size,
+        canShare = sharePlan != null,
+    )
+}
+
+fun shareSelected() {
+    FileUtils.shareFiles(context, selectedItems).fold(
+        onSuccess = viewModel::clearSelection,
+        onFailure = {
+            scope.launch {
+                snackbarHostState.showSnackbar(
+                    "Could not share the selected files. Check that access is still available and try again.",
+                )
+            }
+        },
+    )
+}
+
+if (SelectionToolbarAction.SHARE in selectionToolbarModel.primaryActions) {
+    IconButton(onClick = ::shareSelected, enabled = runningOperation == null) {
+        Icon(Icons.Filled.Share, "Share")
+    }
+}
+```
+
+- [ ] **Step 10: Commit sharing**
+
+```bash
+git add app/src/main/java/com/voyagerfiles/util/ShareIntentPlan.kt app/src/test/java/com/voyagerfiles/util/ShareIntentPlanTest.kt app/src/androidTest/java/com/voyagerfiles/util/FileSharingTest.kt app/src/main/java/com/voyagerfiles/util/FileUtils.kt app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt
+git commit -m "feat: share local and document-tree files"
+```
+
+### Task 3: Offer Trash and permanent delete per operation
+
+**Files:**
+- Create: `app/src/main/java/com/voyagerfiles/viewmodel/DeleteMode.kt`
+- Create: `app/src/main/java/com/voyagerfiles/ui/components/DeleteChoiceDialog.kt`
+- Create: `app/src/test/java/com/voyagerfiles/ui/components/DeleteChoiceDialogModelTest.kt`
+- Create: `app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserSelectionActionsTest.kt`
+- Modify: `app/src/main/java/com/voyagerfiles/viewmodel/FileBrowserViewModel.kt:356-392`
+- Modify: `app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt:697-712`
+
+**Interfaces:**
+- Produces: `enum class DeleteMode { TRASH, PERMANENT }`
+- Produces: `FileBrowserViewModel.deleteSelected(mode: DeleteMode? = null)`
+- Produces: `DeleteChoiceDialogModel.local(count: Int, fileName: String): DeleteChoiceDialogModel`
+- Produces: `DeleteChoiceDialog(model, onDismiss, onMoveToTrash, onDeletePermanently)`
+
+- [ ] **Step 1: Write failing local-choice copy tests**
+
+```kotlin
+@Test
+fun singleItemNamesBothOutcomesAndIrreversibility() {
+    val model = DeleteChoiceDialogModel.local(1, "notes.txt")
+
+    assertEquals("Delete \"notes.txt\"?", model.title)
+    assertTrue(model.message.contains("restore"))
+    assertTrue(model.message.contains("cannot be undone"))
+    assertEquals("Move to Trash", model.trashLabel)
+    assertEquals("Delete permanently", model.permanentLabel)
+}
+
+@Test
+fun multipleItemsUseTheSelectionCount() {
+    assertEquals("Delete 3 items?", DeleteChoiceDialogModel.local(3, "").title)
+}
+```
+
+- [ ] **Step 2: Run the dialog-model test and confirm RED**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.ui.components.DeleteChoiceDialogModelTest`
+
+Expected: compilation fails because the choice model does not exist.
+
+- [ ] **Step 3: Implement the model and Material 3 dialog**
+
+```kotlin
+data class DeleteChoiceDialogModel(
+    val title: String,
+    val message: String,
+    val trashLabel: String = "Move to Trash",
+    val permanentLabel: String = "Delete permanently",
+) {
+    companion object {
+        fun local(count: Int, fileName: String) = DeleteChoiceDialogModel(
+            title = if (count == 1) "Delete \"$fileName\"?" else "Delete $count items?",
+            message = "Move the selection to Trash so it can be restored later, or delete it permanently. Permanent deletion cannot be undone.",
+        )
+    }
+}
+```
+
+Render Cancel, error-colored Delete permanently, and primary Move to Trash buttons in `DeleteChoiceDialog`. Keep the existing `DeleteConfirmDialog` for permanent-only sources and Trash-screen permanent deletion.
+
+```kotlin
+@Composable
+fun DeleteChoiceDialog(
+    model: DeleteChoiceDialogModel,
+    onDismiss: () -> Unit,
+    onMoveToTrash: () -> Unit,
+    onDeletePermanently: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(model.title) },
+        text = { Text(model.message) },
+        confirmButton = {
+            TextButton(onClick = onMoveToTrash) { Text(model.trashLabel) }
+        },
+        dismissButton = {
+            Row {
+                TextButton(onClick = onDismiss) { Text("Cancel") }
+                TextButton(onClick = onDeletePermanently) {
+                    Text(model.permanentLabel, color = MaterialTheme.colorScheme.error)
+                }
+            }
+        },
+    )
+}
+```
+
+- [ ] **Step 4: Run the dialog-model test and confirm GREEN**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.ui.components.DeleteChoiceDialogModelTest`
+
+Expected: all delete-choice copy tests pass.
+
+- [ ] **Step 5: Accept an explicit delete mode in the ViewModel**
+
+```kotlin
+fun deleteSelected(mode: DeleteMode? = null) {
+    val state = _browseState.value
+    val selectedPaths = state.selectedFiles.toList()
+    if (selectedPaths.isEmpty()) return
+    val resolvedMode = mode ?: if (state.source == FileSource.LOCAL && useTrash.value) {
+        DeleteMode.TRASH
+    } else {
+        DeleteMode.PERMANENT
+    }
+    if (resolvedMode == DeleteMode.TRASH && state.source != FileSource.LOCAL) {
+        showSnackbar("Trash is available only for direct local storage")
+        return
+    }
+    val moveToTrash = resolvedMode == DeleteMode.TRASH
+    val provider = fileProvider
+    launchOperation(if (moveToTrash) "Moving to Trash" else "Deleting") {
+        val count = selectedPaths.size
+        var failed = 0
+        var firstError: Throwable? = null
+        for (path in selectedPaths) {
+            val result = if (moveToTrash) trashManager.moveToTrash(path).map { Unit } else provider.delete(path)
+            result.onFailure { error ->
+                failed++
+                if (firstError == null) firstError = error
+            }
+        }
+        clearSelection()
+        refreshFiles()
+        if (failed > 0) {
+            showSnackbar(
+                OperationMessages.partial(
+                    failed = failed,
+                    total = count,
+                    action = if (moveToTrash) "moved to Trash" else "deleted",
+                    error = checkNotNull(firstError),
+                ),
+            )
+        } else {
+            val action = if (moveToTrash) "moved to Trash" else "permanently deleted"
+            showSnackbar("$count item${if (count > 1) "s" else ""} $action")
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Wire the local choice without mutating the saved preference**
+
+When `state.source == FileSource.LOCAL && useTrash`, show `DeleteChoiceDialog`. Call `deleteSelected(DeleteMode.TRASH)` or `deleteSelected(DeleteMode.PERMANENT)` from the matching button. For all other states, keep the existing permanent-only dialog and call `deleteSelected(DeleteMode.PERMANENT)`.
+
+```kotlin
+if (showDeleteDialog) {
+    val count = state.selectedFiles.size
+    val fileName = state.selectedFiles.firstOrNull()?.substringAfterLast("/").orEmpty()
+    if (state.source == FileSource.LOCAL && useTrash) {
+        DeleteChoiceDialog(
+            model = DeleteChoiceDialogModel.local(count, fileName),
+            onDismiss = { showDeleteDialog = false },
+            onMoveToTrash = {
+                showDeleteDialog = false
+                viewModel.deleteSelected(DeleteMode.TRASH)
+            },
+            onDeletePermanently = {
+                showDeleteDialog = false
+                viewModel.deleteSelected(DeleteMode.PERMANENT)
+            },
+        )
+    } else {
+        DeleteConfirmDialog(
+            model = DeleteDialogModel.permanent(count, fileName),
+            onDismiss = { showDeleteDialog = false },
+            onConfirm = {
+                showDeleteDialog = false
+                viewModel.deleteSelected(DeleteMode.PERMANENT)
+            },
+        )
+    }
+}
+```
+
+- [ ] **Step 7: Add a Compose regression to the existing browser-selection test fixture**
+
+Select a disposable local file, click Delete, and assert that `Move to Trash`, `Delete permanently`, and `cannot be undone` are all visible. Dismiss the dialog without deleting the fixture.
+
+```kotlin
+composeTestRule.onNodeWithText("notes.txt").performTouchInput { longClick() }
+composeTestRule.onNodeWithContentDescription("Delete").performClick()
+composeTestRule.onNodeWithText("Move to Trash").assertIsDisplayed()
+composeTestRule.onNodeWithText("Delete permanently").assertIsDisplayed()
+composeTestRule.onNodeWithText("Permanent deletion cannot be undone.", substring = true).assertIsDisplayed()
+composeTestRule.onNodeWithText("Cancel").performClick()
+```
+
+- [ ] **Step 8: Run focused JVM and device tests**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.ui.components.DeleteChoiceDialogModelTest`
+
+Run: `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew connectedDebugAndroidTest --tests com.voyagerfiles.ui.screens.BrowserSelectionActionsTest`
+
+Expected: copy and Compose delete-choice assertions pass.
+
+- [ ] **Step 9: Commit the per-operation delete choice**
+
+```bash
+git add app/src/main/java/com/voyagerfiles/viewmodel/DeleteMode.kt app/src/main/java/com/voyagerfiles/ui/components/DeleteChoiceDialog.kt app/src/test/java/com/voyagerfiles/ui/components/DeleteChoiceDialogModelTest.kt app/src/main/java/com/voyagerfiles/viewmodel/FileBrowserViewModel.kt app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserSelectionActionsTest.kt
+git commit -m "feat: choose Trash or permanent delete"
+```
+
+### Task 4: Add persistent compact list and explicit view options
+
+**Files:**
+- Modify: `app/src/main/java/com/voyagerfiles/data/model/FileItem.kt:147-150`
+- Modify: `app/src/main/java/com/voyagerfiles/ui/components/FileListItem.kt`
+- Modify: `app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt:280-346,580-619,827-841`
+- Modify: `app/src/test/java/com/voyagerfiles/ui/screens/BrowserToolbarModelTest.kt`
+- Modify: `app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserSelectionActionsTest.kt`
+
+**Interfaces:**
+- Produces: `ViewMode.COMPACT`
+- Produces: `ViewMode.label: String` with `List`, `Compact list`, and `Grid`
+- Produces: `FileListItem(..., compact: Boolean = false)`
+- Replaces: `BrowserToolbarAction.TOGGLE_VIEW` with `BrowserToolbarAction.VIEW_OPTIONS`
+
+- [ ] **Step 1: Write a failing view-label test**
+
+```kotlin
+@Test
+fun viewModesHaveUserFacingLabels() {
+    assertEquals("List", ViewMode.LIST.label)
+    assertEquals("Compact list", ViewMode.COMPACT.label)
+    assertEquals("Grid", ViewMode.GRID.label)
+}
+```
+
+- [ ] **Step 2: Run the focused test and confirm RED**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.ui.screens.BrowserToolbarModelTest`
+
+Expected: compilation fails because Compact and label do not exist.
+
+- [ ] **Step 3: Add the compact enum value and labels**
+
+```kotlin
+enum class ViewMode(val label: String) {
+    LIST("List"),
+    COMPACT("Compact list"),
+    GRID("Grid"),
+}
+```
+
+The existing DataStore parser already persists enum names and falls back to List on unknown values.
+
+- [ ] **Step 4: Render compact rows through the existing list component**
+
+Add `compact: Boolean = false` to `FileListItem`. For compact rows use 8dp horizontal padding, 4dp vertical padding, a 32dp icon, 12dp icon-to-text spacing, and `Modifier.heightIn(min = 48.dp)`. Keep both the name and metadata and retain the existing comfortable values when `compact` is false.
+
+```kotlin
+val horizontalPadding = if (compact) 8.dp else 16.dp
+val verticalPadding = if (compact) 4.dp else 12.dp
+val iconSize = if (compact) 32.dp else 40.dp
+val iconSpacing = if (compact) 12.dp else 16.dp
+val nameStyle = if (compact) MaterialTheme.typography.bodyMedium else MaterialTheme.typography.bodyLarge
+
+Row(
+    modifier = Modifier
+        .heightIn(min = 48.dp)
+        .padding(horizontal = horizontalPadding, vertical = verticalPadding),
+    verticalAlignment = Alignment.CenterVertically,
+) {
+    FileThumbnailOrIcon(file = file, iconSize = iconSize)
+    Spacer(modifier = Modifier.width(iconSpacing))
+    Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.Center) {
+        Text(
+            text = file.name,
+            style = nameStyle,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            if (!file.isDirectory) {
+                Text(
+                    text = file.formattedSize,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Text(
+                text = formatDate(file.lastModified),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+```
+
+Keep the exact padding, icon size, text style, metadata, and 48dp minimum above.
+
+- [ ] **Step 5: Replace the binary toggle with a labeled view menu**
+
+Open a `DropdownMenu` from the existing toolbar slot. Show List, Compact list, and Grid with matching Material icons and a trailing check on the active mode. Use `View options, current ${state.viewMode.label}` as the icon content description. Selecting an entry calls `viewModel.setViewMode(mode)` and closes the menu.
+
+```kotlin
+Box {
+    IconButton(onClick = { showViewMenu = true }) {
+        Icon(
+            imageVector = when (state.viewMode) {
+                ViewMode.GRID -> Icons.Filled.GridView
+                ViewMode.LIST, ViewMode.COMPACT -> Icons.AutoMirrored.Filled.ViewList
+            },
+            contentDescription = "View options, current ${state.viewMode.label}",
+        )
+    }
+    DropdownMenu(
+        expanded = showViewMenu,
+        onDismissRequest = { showViewMenu = false },
+    ) {
+        ViewMode.entries.forEach { mode ->
+            DropdownMenuItem(
+                text = { Text(mode.label) },
+                trailingIcon = {
+                    if (state.viewMode == mode) Icon(Icons.Filled.Check, null)
+                },
+                onClick = {
+                    viewModel.setViewMode(mode)
+                    showViewMenu = false
+                },
+            )
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Render List and Compact through `LazyColumn`**
+
+```kotlin
+state.viewMode == ViewMode.LIST || state.viewMode == ViewMode.COMPACT -> {
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
+        items(state.visibleFiles, key = { it.path }) { file ->
+            FileListItem(
+                file = file,
+                compact = state.viewMode == ViewMode.COMPACT,
+                isSelected = file.path in state.selectedFiles,
+                isSelectionMode = isSelectionMode,
+                onClick = {
+                    if (isSelectionMode) {
+                        viewModel.toggleSelection(file.path)
+                    } else if (file.isDirectory) {
+                        navigateTo(file.path)
+                    } else if (isNetwork) {
+                        viewModel.downloadFile(file.path)
+                    } else if (state.source == FileSource.LOCAL || state.source == FileSource.SAF) {
+                        runCatching { FileUtils.openFile(context, file) }.onFailure {
+                            scope.launch {
+                                snackbarHostState.showSnackbar("No app found to open this file")
+                            }
+                        }
+                    }
+                },
+                onLongClick = { viewModel.toggleSelection(file.path) },
+            )
+        }
+    }
+}
+```
+
+- [ ] **Step 7: Add a Compose view-options regression**
+
+Open View options, assert all three labels, choose Compact list, and assert that the icon label changes to `View options, current Compact list`. Recreate the browser content with the same ViewModel and assert Compact remains selected.
+
+```kotlin
+composeTestRule.onNodeWithContentDescription("View options, current List").performClick()
+composeTestRule.onNodeWithText("List").assertIsDisplayed()
+composeTestRule.onNodeWithText("Compact list").assertIsDisplayed().performClick()
+composeTestRule.onNodeWithContentDescription("View options, current Compact list").assertIsDisplayed()
+
+composeTestRule.activityRule.scenario.recreate()
+composeTestRule.waitUntil(timeoutMillis = 10_000) {
+    composeTestRule.onAllNodesWithContentDescription("View options, current Compact list")
+        .fetchSemanticsNodes().isNotEmpty()
+}
+```
+
+- [ ] **Step 8: Run focused JVM and device tests**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.ui.screens.BrowserToolbarModelTest`
+
+Run: `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew connectedDebugAndroidTest --tests com.voyagerfiles.ui.screens.BrowserSelectionActionsTest`
+
+Expected: view labels, menu behavior, and compact persistence assertions pass.
+
+- [ ] **Step 9: Commit view options**
+
+```bash
+git add app/src/main/java/com/voyagerfiles/data/model/FileItem.kt app/src/main/java/com/voyagerfiles/ui/components/FileListItem.kt app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt app/src/test/java/com/voyagerfiles/ui/screens/BrowserToolbarModelTest.kt app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserSelectionActionsTest.kt
+git commit -m "feat: add compact list view options"
+```
+
+### Task 5: Add a focused file Details sheet
+
+**Files:**
+- Create: `app/src/main/java/com/voyagerfiles/ui/components/FileDetailsSheet.kt`
+- Create: `app/src/androidTest/java/com/voyagerfiles/ui/components/FileDetailsSheetTest.kt`
+- Modify: `app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt:117-274,714-726`
+
+**Interfaces:**
+- Produces: `FileDetailsSheet(file: FileItem, onDismiss: () -> Unit)`
+- Consumes: `SelectionToolbarAction.DETAILS` from Task 1.
+
+- [ ] **Step 1: Write a failing Compose details test**
+
+```kotlin
+@Test
+fun detailsShowsAvailableMetadata() {
+    composeTestRule.setContent {
+        VoyagerTheme {
+            FileDetailsSheet(
+                file = FileItem(
+                    name = "report.pdf",
+                    path = "/storage/emulated/0/Documents/report.pdf",
+                    isDirectory = false,
+                    size = 2048,
+                    owner = "media_rw",
+                    permissions = "rw-r--r--",
+                ),
+                onDismiss = {},
+            )
+        }
+    }
+
+    composeTestRule.onNodeWithText("Details").assertIsDisplayed()
+    composeTestRule.onNodeWithText("report.pdf").assertIsDisplayed()
+    composeTestRule.onNodeWithText("2 KB").assertIsDisplayed()
+    composeTestRule.onNodeWithText("/storage/emulated/0/Documents/report.pdf").assertIsDisplayed()
+    composeTestRule.onNodeWithText("media_rw").assertIsDisplayed()
+    composeTestRule.onNodeWithText("rw-r--r--").assertIsDisplayed()
+}
+```
+
+- [ ] **Step 2: Run the focused Compose test and confirm RED**
+
+Run: `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew connectedDebugAndroidTest --tests com.voyagerfiles.ui.components.FileDetailsSheetTest`
+
+Expected: compilation fails because `FileDetailsSheet` does not exist.
+
+- [ ] **Step 3: Implement the read-only Material sheet**
+
+Use `ModalBottomSheet`, a `LazyColumn`, and small label-value rows for Name, Type, Size for files, Modified, Source, Path, Owner when present, and Permissions when present. Use Android `DateFormat.getDateTimeInstance` for the modified value. Make the path selectable and allow long values to wrap. Do not calculate recursive folder size.
+
+```kotlin
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FileDetailsSheet(file: FileItem, onDismiss: () -> Unit) {
+    val modified = remember(file.lastModified) {
+        DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT).format(file.lastModified)
+    }
+    val rows = buildList {
+        add("Name" to file.name)
+        add("Type" to if (file.isDirectory) "Folder" else file.mimeType)
+        if (!file.isDirectory) add("Size" to file.formattedSize)
+        add("Modified" to modified)
+        add("Source" to file.source.displayLabel)
+        add("Path" to file.path)
+        file.owner?.takeIf(String::isNotBlank)?.let { add("Owner" to it) }
+        file.permissions?.takeIf(String::isNotBlank)?.let { add("Permissions" to it) }
+    }
+
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        LazyColumn(
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(start = 24.dp, end = 24.dp, bottom = 32.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            item { Text("Details", style = MaterialTheme.typography.headlineSmall) }
+            items(rows) { (label, value) ->
+                Column {
+                    Text(label, style = MaterialTheme.typography.labelMedium)
+                    SelectionContainer {
+                        Text(value, style = MaterialTheme.typography.bodyLarge)
+                    }
+                }
+            }
+        }
+    }
+}
+
+private val FileSource.displayLabel: String
+    get() = when (this) {
+        FileSource.LOCAL -> "Local storage"
+        FileSource.SAF -> "Document tree"
+        FileSource.SFTP -> "SFTP"
+        FileSource.FTP -> "FTP"
+        FileSource.SMB -> "SMB"
+        FileSource.WEBDAV -> "WebDAV"
+    }
+```
+
+- [ ] **Step 4: Run the focused Compose test and confirm GREEN**
+
+Run: `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew connectedDebugAndroidTest --tests com.voyagerfiles.ui.components.FileDetailsSheetTest`
+
+Expected: all available labels and values are visible.
+
+- [ ] **Step 5: Wire Details into the single-selection overflow**
+
+Store `showDetailsFor: FileItem?` with `remember`, assign the single selected item when Details is chosen, close the overflow menu, and render `FileDetailsSheet`. Dismissing the sheet keeps the item selected so the user can immediately take another action.
+
+```kotlin
+var showDetailsFor by remember { mutableStateOf<FileItem?>(null) }
+
+if (SelectionToolbarAction.DETAILS in selectionToolbarModel.overflowActions) {
+    DropdownMenuItem(
+        text = { Text("Details") },
+        leadingIcon = { Icon(Icons.Filled.Info, null) },
+        onClick = {
+            showDetailsFor = selectedItems.single()
+            showSelectionMoreMenu = false
+        },
+    )
+}
+
+showDetailsFor?.let { file ->
+    FileDetailsSheet(
+        file = file,
+        onDismiss = { showDetailsFor = null },
+    )
+}
+```
+
+- [ ] **Step 6: Commit Details**
+
+```bash
+git add app/src/main/java/com/voyagerfiles/ui/components/FileDetailsSheet.kt app/src/androidTest/java/com/voyagerfiles/ui/components/FileDetailsSheetTest.kt app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt
+git commit -m "feat: show selected file details"
+```
+
+### Task 6: Final accessibility, documentation, device, and regression verification
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/ARCHITECTURE.md`
+- Modify: `docs/TESTING.md`
+- Modify: `fastlane/metadata/android/en-US/full_description.txt`
+- Modify: `app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserSelectionActionsTest.kt`
+- Refresh only if visually representative: `docs/screenshots/browser.png`
+
+**Interfaces:**
+- Verifies every interface from Tasks 1 through 5.
+
+- [ ] **Step 1: Add the end-to-end selection-action Compose regression**
+
+Using a temporary local directory containing one text file and one folder, verify:
+
+- One selected file exposes Share, Rename, and Delete as primary action descriptions.
+- One selected folder exposes Copy, Rename, and Delete, with Share absent.
+- Two selected files expose Copy, Share, and Delete, with Rename absent.
+- Details appears only for exactly one selection.
+- The local delete dialog contains both outcomes and irreversible wording.
+
+Use these concrete assertions after the test fixture has opened the temporary directory:
+
+```kotlin
+composeTestRule.onNodeWithText("notes.txt").performTouchInput { longClick() }
+composeTestRule.onNodeWithContentDescription("Share").assertIsDisplayed()
+composeTestRule.onNodeWithContentDescription("Rename").assertIsDisplayed()
+composeTestRule.onNodeWithContentDescription("Delete").assertIsDisplayed()
+
+composeTestRule.onNodeWithContentDescription("More selection actions").performClick()
+composeTestRule.onNodeWithText("Details").assertIsDisplayed()
+composeTestRule.onNodeWithText("Cut").assertIsDisplayed()
+composeTestRule.onNodeWithText("Copy").assertIsDisplayed()
+composeTestRule.onNodeWithText("Select all visible").performClick()
+
+composeTestRule.onNodeWithContentDescription("Rename").assertDoesNotExist()
+composeTestRule.onNodeWithContentDescription("Share").assertDoesNotExist()
+composeTestRule.onNodeWithContentDescription("Delete").assertIsDisplayed()
+```
+
+- [ ] **Step 2: Run all focused changed-area tests**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.ui.screens.BrowserToolbarModelTest --tests com.voyagerfiles.util.ShareIntentPlanTest --tests com.voyagerfiles.ui.components.DeleteChoiceDialogModelTest`
+
+Run: `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew connectedDebugAndroidTest --tests com.voyagerfiles.util.FileSharingTest --tests com.voyagerfiles.ui.components.FileDetailsSheetTest --tests com.voyagerfiles.ui.screens.BrowserSelectionActionsTest`
+
+Expected: every focused test passes.
+
+- [ ] **Step 3: Update capability documentation**
+
+Update public wording only for implemented behavior: local and SAF single or multi-file sharing, per-operation Trash or permanent delete, primary single-item rename, List/Compact/Grid modes, and Details. Record remote temporary-file sharing, directory archive sharing, batch rename, and recursive folder size as remaining work only in internal architecture or testing notes, not as shipped claims.
+
+- [ ] **Step 4: Build and install the current debug APK**
+
+Run: `./gradlew assembleDebug`
+
+Run: `adb -s 192.168.27.167:5555 install -r app/build/outputs/apk/debug/app-arm64-v8a-debug.apk`
+
+Expected: build and install succeed for `com.voyagerfiles.debug`.
+
+- [ ] **Step 5: Exercise disposable local fixtures on the K60**
+
+Create a dedicated `/sdcard/VoyagerDailyActionsTest` folder and verify:
+
+- Share one local file and two mixed-type files; the Android chooser appears and receiving targets can read each URI.
+- Share one SAF file when a persisted document-tree grant is available.
+- Rename a file and confirm the directory refreshes with the new name.
+- Move one file to Trash, restore it, then permanently delete a separate disposable file from the browser choice dialog.
+- Switch List to Compact list to Grid, relaunch the app, and confirm the last mode persists.
+- Open Details for a file and a folder, rotate portrait to landscape and back, and confirm layout and selection recovery.
+- Capture fresh before and after screenshots at the same orientation for visual comparison.
+- Inspect `adb logcat -d -b crash` and the app process log for new fatal exceptions.
+
+- [ ] **Step 6: Run the clean full verification gate**
+
+Run: `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew clean testDebugUnitTest lintDebug assembleDebug assembleRelease connectedDebugAndroidTest --stacktrace`
+
+Expected: all JVM and device tests pass, lint has zero errors, and debug and release APKs are produced.
+
+- [ ] **Step 7: Review warnings, artifacts, and the final diff**
+
+Inspect the lint XML by warning ID, aggregate test XML counts, run `git diff --check`, confirm no fixture or audit file is tracked, confirm version 1.3.0 remains unchanged during feature work, and review every changed production file for error paths, selection state, and accessibility labels.
+
+- [ ] **Step 8: Remove device fixtures and restore user state**
+
+Remove `/sdcard/VoyagerDailyActionsTest`, restore the device's original rotation settings, leave no instrumentation dialogs open, and confirm `adb shell dumpsys window` shows no Voyager crash dialog.
+
+- [ ] **Step 9: Commit documentation and final regression coverage**
+
+```bash
+git add README.md docs/ARCHITECTURE.md docs/TESTING.md fastlane/metadata/android/en-US/full_description.txt app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserSelectionActionsTest.kt docs/screenshots/browser.png
+git commit -m "docs: document daily file actions"
+```
+
+- [ ] **Step 10: Publish only after the milestone is release quality**
+
+Push `codex/daily-file-actions`, open a ready pull request with exact verification evidence, wait for GitHub CI, merge with a merge commit, and re-run the smallest post-merge verification on `master`. Prepare a separate semantic version bump and signed release only if the complete milestone, store metadata, and release notes are coherent and the user-authorized publication checks all pass.

--- a/docs/superpowers/plans/2026-07-14-daily-actions-sharing-view-implementation.md
+++ b/docs/superpowers/plans/2026-07-14-daily-actions-sharing-view-implementation.md
@@ -314,7 +314,7 @@ private fun safFile(uri: Uri) = FileItem(
 
 - [ ] **Step 6: Run the Android intent test and confirm RED**
 
-Run: `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew connectedDebugAndroidTest --tests com.voyagerfiles.util.FileSharingTest`
+Run: `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew -Pandroid.testInstrumentationRunnerArguments.class=com.voyagerfiles.util.FileSharingTest connectedDebugAndroidTest`
 
 Expected: compilation fails because `createShareIntent` does not exist.
 
@@ -350,7 +350,7 @@ fun shareFiles(context: Context, files: List<FileItem>): Result<Unit> =
 
 Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.util.ShareIntentPlanTest`
 
-Run: `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew connectedDebugAndroidTest --tests com.voyagerfiles.util.FileSharingTest`
+Run: `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew -Pandroid.testInstrumentationRunnerArguments.class=com.voyagerfiles.util.FileSharingTest connectedDebugAndroidTest`
 
 Expected: both focused suites pass.
 
@@ -592,7 +592,7 @@ composeTestRule.onNodeWithText("Cancel").performClick()
 
 Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.ui.components.DeleteChoiceDialogModelTest`
 
-Run: `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew connectedDebugAndroidTest --tests com.voyagerfiles.ui.screens.BrowserSelectionActionsTest`
+Run: `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew -Pandroid.testInstrumentationRunnerArguments.class=com.voyagerfiles.ui.screens.BrowserSelectionActionsTest connectedDebugAndroidTest`
 
 Expected: copy and Compose delete-choice assertions pass.
 
@@ -782,7 +782,7 @@ composeTestRule.waitUntil(timeoutMillis = 10_000) {
 
 Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.ui.screens.BrowserToolbarModelTest`
 
-Run: `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew connectedDebugAndroidTest --tests com.voyagerfiles.ui.screens.BrowserSelectionActionsTest`
+Run: `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew -Pandroid.testInstrumentationRunnerArguments.class=com.voyagerfiles.ui.screens.BrowserSelectionActionsTest connectedDebugAndroidTest`
 
 Expected: view labels, menu behavior, and compact persistence assertions pass.
 
@@ -836,7 +836,7 @@ fun detailsShowsAvailableMetadata() {
 
 - [ ] **Step 2: Run the focused Compose test and confirm RED**
 
-Run: `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew connectedDebugAndroidTest --tests com.voyagerfiles.ui.components.FileDetailsSheetTest`
+Run: `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew -Pandroid.testInstrumentationRunnerArguments.class=com.voyagerfiles.ui.components.FileDetailsSheetTest connectedDebugAndroidTest`
 
 Expected: compilation fails because `FileDetailsSheet` does not exist.
 
@@ -894,7 +894,7 @@ private val FileSource.displayLabel: String
 
 - [ ] **Step 4: Run the focused Compose test and confirm GREEN**
 
-Run: `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew connectedDebugAndroidTest --tests com.voyagerfiles.ui.components.FileDetailsSheetTest`
+Run: `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew -Pandroid.testInstrumentationRunnerArguments.class=com.voyagerfiles.ui.components.FileDetailsSheetTest connectedDebugAndroidTest`
 
 Expected: all available labels and values are visible.
 
@@ -977,7 +977,7 @@ composeTestRule.onNodeWithContentDescription("Delete").assertIsDisplayed()
 
 Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.ui.screens.BrowserToolbarModelTest --tests com.voyagerfiles.util.ShareIntentPlanTest --tests com.voyagerfiles.ui.components.DeleteChoiceDialogModelTest`
 
-Run: `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew connectedDebugAndroidTest --tests com.voyagerfiles.util.FileSharingTest --tests com.voyagerfiles.ui.components.FileDetailsSheetTest --tests com.voyagerfiles.ui.screens.BrowserSelectionActionsTest`
+Run: `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew -Pandroid.testInstrumentationRunnerArguments.class=com.voyagerfiles.util.FileSharingTest,com.voyagerfiles.ui.components.FileDetailsSheetTest,com.voyagerfiles.ui.screens.BrowserSelectionActionsTest connectedDebugAndroidTest`
 
 Expected: every focused test passes.
 

--- a/docs/superpowers/specs/2026-07-14-daily-actions-sharing-view-design.md
+++ b/docs/superpowers/specs/2026-07-14-daily-actions-sharing-view-design.md
@@ -1,0 +1,132 @@
+# Voyager Daily Actions, Sharing, and View Options Design
+
+## Purpose
+
+This milestone makes Voyager's most common selected-item actions easier to find and safer to use. It adds per-operation Trash versus permanent deletion, exposes Android sharing for eligible local and document-tree files, promotes rename when one item is selected, adds a compact list presentation alongside the existing list and grid modes, and provides basic file details without changing Voyager's established Compose, Material 3, ViewModel, provider, or DataStore architecture.
+
+The user explicitly requested uninterrupted autonomous work and named direct deletion, Trash choice, viewing modes, sharing, and renaming as priorities. That instruction supplies approval to choose the conservative implementation described here without pausing for another review gate.
+
+## Audit scope
+
+The audit covered the Home screen, local browser, current-folder search, list mode, grid mode, single selection, the selection overflow menu, and the delete confirmation flow on a K60 running Android 16. Fresh screenshots and UI hierarchy captures were inspected in portrait and landscape. Source inspection covered `BrowserScreen`, `FileListItem`, `FileGridItem`, `FileUtils`, `FileBrowserViewModel`, `PreferencesManager`, the FileProvider manifest configuration, and existing JVM and instrumentation coverage.
+
+## User goal and accessibility target
+
+A daily file-manager user should be able to select an item and immediately understand how to share, rename, copy, move, inspect, or delete it. Destructive choices must clearly distinguish recoverable Trash from irreversible deletion. View controls must state the destination mode instead of presenting an ambiguous toggle. Changed controls should retain at least 48dp touch targets, meaningful TalkBack labels, readable narrow-phone layouts, and stable state through configuration changes.
+
+## Confirmed strengths
+
+- Voyager already provides persistent list and grid modes, current-folder search and type filters, sorting, multi-selection, copy and cut, responsive browser layouts, clear loading and empty states, and per-volume Trash.
+- The selected row has a strong visual state and an explicit checkbox, while the contextual top bar clearly reports the selection count.
+- File rows show useful size and modification metadata, and grid items use familiar file-type icons and two-line names.
+- The existing `FileProvider` configuration can grant read access to direct local files, while SAF item paths are already content URIs.
+- Rename validates names before provider calls, deletion requires confirmation, and local deletion defaults to recoverable Trash.
+
+## UX risks
+
+- `FileUtils.shareFile` exists but is unused, handles only one direct local file, and cannot share SAF or multiple selections. Users therefore have no visible Share action.
+- Rename is available only in the overflow menu for a single selection, while copy and cut occupy two scarce primary action slots. This makes a frequent single-item action unnecessarily hard to discover.
+- When Trash is enabled, the delete dialog offers only Move to Trash. Permanently deleting the current selection requires leaving the browser, changing a global setting, returning, deleting, and optionally restoring the setting.
+- The view control is labeled only `Toggle view`. It does not announce the destination mode and cannot offer a denser list for large folders.
+- The browser has no concise Details surface for path, type, size, and modified time, so users must infer or leave the app for basic information.
+
+## Accessibility risks
+
+- The generic `Toggle view` description does not tell assistive-technology users what will happen.
+- Contextual action ordering prioritizes implementation concepts such as copy and cut over common user outcomes such as share and rename.
+- Share eligibility and permanent-delete consequences are not currently representable because the actions are absent.
+- This audit did not run a complete TalkBack traversal, external keyboard pass, switch-access pass, or formal contrast measurement, so it does not claim full accessibility compliance.
+
+## Considered approaches
+
+### Approach A: Context-aware top bar plus focused dialogs and sheets
+
+This is the selected approach. Keep the existing contextual top bar, but derive its three primary actions from selection count and share eligibility. Add a per-operation delete choice, a small view-options menu, a focused details sheet, and a reusable share intent builder. This preserves Voyager's current design and architecture, requires no runtime dependency, and supports multi-selection.
+
+### Approach B: Replace selection mode with a modal action sheet
+
+A full action sheet could expose every operation with text labels, but it would add a navigation layer to every selection, displace the current fast actions, and require a broader interaction rewrite. It also makes repeated multi-select operations slower.
+
+### Approach C: Add an overflow button to every file row and grid tile
+
+Per-item menus are discoverable for single files but add visual clutter, complicate grid layout, and do not solve multi-selection. Voyager already has a coherent long-press selection model, so duplicating actions per row would create inconsistent paths.
+
+## Selected interaction design
+
+### Contextual actions
+
+The top bar will continue to show at most three primary actions plus overflow on narrow phones.
+
+- One shareable file: Share, Rename, Delete are primary. Copy, Cut, Select all visible, and Details are in overflow.
+- One non-shareable item: Copy, Rename, Delete are primary. Cut, Select all visible, Details, and remote Download when applicable are in overflow.
+- Multiple shareable files: Copy, Share, Delete are primary. Cut and Select all visible are in overflow.
+- Multiple selections containing a directory, or remote selections: Copy and Delete remain primary. Cut, Select all visible, and remote Download are in overflow.
+
+A selection is shareable only when every selected item is a non-directory item from a direct local or SAF session. Remote sharing remains a future enhancement because it requires downloading and managing temporary files. Voyager's existing Download action remains available for remote selections.
+
+### Per-operation deletion
+
+For a direct local selection when Trash is enabled, the delete dialog will offer three explicit actions: Cancel, Delete permanently, and Move to Trash. Move to Trash remains the visually preferred safe action. Delete permanently uses the error color and the dialog states that it cannot be undone. This one dialog is the required destructive confirmation.
+
+When Trash is disabled, or the selection belongs to SAF or a remote provider, the existing permanent-delete confirmation remains. The ViewModel will accept an explicit `DeleteMode` so the per-operation choice cannot race with or mutate the saved preference. Requesting Trash for a non-local source will fail safely and leave the selection intact.
+
+### Sharing
+
+`FileUtils.shareFiles(context, files)` will support one or many eligible items. Direct local paths will become `FileProvider` content URIs. SAF paths will remain their existing content URIs. A single item will use `ACTION_SEND`; multiple items will use `ACTION_SEND_MULTIPLE`. The intent will include read grants and `ClipData` so receiving apps can open every URI.
+
+When every selected file has the same MIME type, Voyager will use it. If MIME types differ, the share type will use the common top-level family such as `image/*`; otherwise it will use `*/*`. Voyager will open Android's chooser and report an actionable snackbar if URI creation or chooser launch fails. Starting the chooser clears selection only after the intent has been created successfully.
+
+### View options
+
+The existing List and Grid modes remain, and a third Compact list mode will be added. Compact list keeps file metadata but reduces vertical padding, icon size, and spacing so more items fit on screen without shrinking touch targets below 48dp. The existing toolbar slot will open a View options menu with List, Compact list, and Grid entries and a check beside the active mode. Its content description will include the active mode.
+
+`ViewMode.COMPACT` will be persisted through the existing DataStore preference. Existing stored values continue to parse, and unknown values continue to fall back to List.
+
+### Details
+
+Details will be available for exactly one selected item. A Material 3 bottom sheet will show name, item type, size for files, modified time, source, full path, and provider-supplied owner or permissions when present. The sheet is read-only and does not introduce metadata editing or recursive folder-size calculation.
+
+## Architecture and components
+
+- `SelectionToolbarModel` remains a pure Kotlin model but will consume selection count, source, and whether every selected item is shareable. Its tests define primary and overflow placement.
+- A pure `ShareIntentModel` will determine action type and MIME type without Android framework calls. `FileUtils` will resolve URIs and build the actual chooser intent.
+- `DeleteMode` will make Trash and permanent behavior explicit at the ViewModel boundary. Existing preference behavior remains the default for callers that do not specify a mode.
+- `DeleteChoiceDialog` and `FileDetailsSheet` will live with Voyager's existing focused Compose components. They will receive immutable models and callbacks rather than access the ViewModel directly.
+- `ViewMode.COMPACT` will reuse `FileListItem` with an explicit density parameter rather than duplicate the list component.
+
+## Error handling and recovery
+
+- Share is hidden for directories and unsupported sources instead of failing after the user chooses it.
+- Invalid local paths, revoked SAF grants, or missing chooser activities produce a snackbar and keep the selection.
+- Permanent deletion always includes irreversible wording. Trash remains the default safe action when available.
+- A failed Trash or permanent delete continues to use the existing partial-failure reporting and refresh behavior.
+- Details never performs recursive I/O, so large folders open the sheet immediately.
+- Unknown persisted view values fall back to List, preserving existing recovery behavior.
+
+## Testing and verification
+
+Implementation will follow red, green, refactor cycles.
+
+- JVM tests will cover contextual action placement, share eligibility, single versus multiple intent models, MIME-type merging, delete dialog wording, and view-mode parsing behavior that can be isolated from DataStore.
+- Compose instrumentation tests will verify Share and Rename visibility, the three-action local delete dialog, permanent-delete wording, view-option labels, compact-row accessibility, and the Details sheet.
+- Existing unit and instrumentation suites must remain green.
+- Device verification on the K60 will share one file and multiple mixed-type files through Android's chooser, verify SAF sharing when a document-tree grant is available, rename a file, exercise both Trash and permanent deletion on disposable fixtures, switch among all three view modes, rotate the app, and inspect logcat for crashes.
+- The full gate remains `testDebugUnitTest`, `lintDebug`, `assembleDebug`, `assembleRelease`, and `connectedDebugAndroidTest`.
+
+## Out of scope
+
+- Sharing directories as archives.
+- Sharing remote files through temporary downloads.
+- Batch rename, archive creation or extraction, file hashing, recursive folder-size calculation, and metadata editing.
+- Replacing the selection model, navigation system, provider interface, or visual design system.
+
+## Acceptance criteria
+
+- Eligible local and SAF files can be shared singly or together through Android's chooser with readable URIs.
+- Share is not offered for directories or remote items.
+- Rename is a primary action whenever exactly one item is selected.
+- Local deletion with Trash enabled offers both recoverable Trash and explicit permanent deletion in the same confirmation dialog.
+- Permanent delete wording states that the action cannot be undone, and no destructive action runs without confirmation.
+- List, Compact list, and Grid are selectable, persistent, and correctly labeled for assistive technology.
+- Details accurately reports the selected item's available metadata without blocking on recursive work.
+- Narrow portrait and landscape layouts remain readable, changed controls retain 48dp targets, and all focused and full verification commands pass.

--- a/fastlane/metadata/android/en-US/changelogs/12.txt
+++ b/fastlane/metadata/android/en-US/changelogs/12.txt
@@ -1,0 +1,6 @@
+Release 1.4.0:
+- Share one or several local and document-tree files
+- Choose Trash or permanent deletion for each direct-local operation
+- Switch among persistent List, Compact list, and Grid layouts
+- Inspect selectable file metadata in a Details sheet
+- Find Share, Rename, and Delete faster in contextual selection actions

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,7 +1,9 @@
 Voyager is an open-source file manager for Android with built-in SFTP, FTP, SMB, and WebDAV access, built with Material Design 3 and Jetpack Compose.
 
 Features:
-• Local file browsing with file management (copy, move, rename, delete, create)
+• Local file browsing with file management (copy, move, rename, Trash, permanent delete, create)
+• Share one or several local and document-tree files through Android's system share sheet
+• File details with selectable metadata
 • Image thumbnails for local image files
 • Storage Access Framework document-tree browsing
 • SFTP remote access, with password, keyboard-interactive, private key, or generated key-pair authentication
@@ -15,7 +17,7 @@ Features:
 • 20 built-in themes including Catppuccin, Nord, Solarized, Gruvbox, Rosé Pine, Tokyo Night, and High Contrast
 • Custom theme support
 • AMOLED black theme
-• List and grid view modes
+• List, compact list, and grid view modes
 • Bookmarks and quick access
 • Storage usage overview
 • Hidden files toggle

--- a/metadata/com.voyagerfiles.yml
+++ b/metadata/com.voyagerfiles.yml
@@ -69,9 +69,18 @@ Builds:
     gradleprops:
       - voyager.enableAbiSplits=false
 
+  - versionName: 1.4.0
+    versionCode: 12
+    commit: 8d8a2c760d697dd4223dfd93c1418e97451e25d8
+    subdir: app
+    gradle:
+      - yes
+    gradleprops:
+      - voyager.enableAbiSplits=false
+
 AllowedAPKSigningKeys: db496277d456751abe8ca6405026337c81a561a134e38d49c8e21fb8f036badf
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
-CurrentVersion: 1.3.0
-CurrentVersionCode: 11
+CurrentVersion: 1.4.0
+CurrentVersionCode: 12

--- a/metadata/en-US/changelogs/12.txt
+++ b/metadata/en-US/changelogs/12.txt
@@ -1,0 +1,6 @@
+Voyager 1.4.0:
+- Added single and multiple file sharing for local and document-tree files
+- Added per-operation Trash or permanent deletion choices for local files
+- Added persistent List, Compact list, and Grid layouts
+- Added a Details sheet with selectable file metadata
+- Improved contextual selection actions


### PR DESCRIPTION
## Summary

- promote Share, Rename, and Delete in contextual selection actions
- share one or several local and document-tree files through the Android chooser
- offer Trash or permanent deletion for each direct-local delete operation
- persist List, Compact list, and Grid layouts
- add a selectable file Details sheet
- prepare Android and F-Droid metadata for version 1.4.0

## Verification

- `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew clean testDebugUnitTest lintDebug assembleDebug assembleRelease connectedDebugAndroidTest --stacktrace`
- 104 JVM tests completed with 2 credential-gated SMB skips and no failures or errors
- 14 Android instrumentation tests passed on a K60 running Android 16
- lint completed with 0 errors and 18 pre-existing warnings
- verified single and multiple sharing, rename, Trash and restore, permanent delete, view persistence, details, rotation, and malformed-image fallback on the K60
- verified the release APK metadata reports version code 12 and version name 1.4.0