### PR TITLE
Restore remote create actions and add direct uploads

### DIFF
--- a/app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserCreateMenuTest.kt
+++ b/app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserCreateMenuTest.kt
@@ -1,0 +1,35 @@
+package com.voyagerfiles.ui.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Rule
+import org.junit.Test
+
+class BrowserCreateMenuTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun remoteMenuShowsCreateAndUploadCommands() {
+        composeTestRule.setContent {
+            MaterialTheme {
+                Box {
+                    BrowserCreateMenu(
+                        expanded = true,
+                        model = BrowserCreateMenuModel.forState(isRemote = true),
+                        onDismiss = {},
+                        onAction = {},
+                    )
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithText("New Folder").assertIsDisplayed()
+        composeTestRule.onNodeWithText("New File").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Upload Files").assertIsDisplayed()
+    }
+}

--- a/app/src/androidTest/java/com/voyagerfiles/viewmodel/DocumentUploadTest.kt
+++ b/app/src/androidTest/java/com/voyagerfiles/viewmodel/DocumentUploadTest.kt
@@ -1,0 +1,100 @@
+package com.voyagerfiles.viewmodel
+
+import android.app.Application
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.core.content.FileProvider
+import androidx.test.core.app.ApplicationProvider
+import java.io.File
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class DocumentUploadTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var fixtureRoot: File
+
+    @Before
+    fun setUp() {
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        fixtureRoot = File(application.cacheDir, "document-upload-test").apply {
+            deleteRecursively()
+            mkdirs()
+        }
+    }
+
+    @After
+    fun tearDown() {
+        fixtureRoot.deleteRecursively()
+    }
+
+    @Test
+    fun contentUriUploadsIntoTheActiveDirectory() {
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        val source = fixtureRoot.resolve("report.txt").apply { writeText("document upload") }
+        val destination = fixtureRoot.resolve("destination").apply { mkdirs() }
+        val sourceUri = FileProvider.getUriForFile(
+            application,
+            "${application.packageName}.fileprovider",
+            source,
+        )
+        val viewModel = FileBrowserViewModel(application)
+        composeTestRule.setContent {}
+        composeTestRule.runOnIdle { viewModel.openLocalRoot(destination.absolutePath) }
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            viewModel.browseState.value.currentPath == destination.absolutePath &&
+                !viewModel.browseState.value.isLoading
+        }
+
+        composeTestRule.runOnIdle { viewModel.uploadDocuments(listOf(sourceUri)) }
+
+        val uploaded = destination.resolve(source.name)
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            viewModel.operationState.value == OperationState.Idle && uploaded.exists()
+        }
+        assertEquals(source.readText(), uploaded.readText())
+    }
+
+    @Test
+    fun conflictingDocumentDoesNotOverwriteOrBlockOtherUploads() {
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        val conflictingSource = fixtureRoot.resolve("report.txt").apply { writeText("replacement") }
+        val newSource = fixtureRoot.resolve("notes.txt").apply { writeText("new upload") }
+        val destination = fixtureRoot.resolve("destination").apply {
+            mkdirs()
+            resolve("report.txt").writeText("existing")
+        }
+        val authority = "${application.packageName}.fileprovider"
+        val viewModel = FileBrowserViewModel(application)
+        composeTestRule.setContent {}
+        composeTestRule.runOnIdle { viewModel.openLocalRoot(destination.absolutePath) }
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            viewModel.browseState.value.currentPath == destination.absolutePath &&
+                !viewModel.browseState.value.isLoading
+        }
+
+        composeTestRule.runOnIdle {
+            viewModel.uploadDocuments(
+                listOf(
+                    FileProvider.getUriForFile(application, authority, conflictingSource),
+                    FileProvider.getUriForFile(application, authority, newSource),
+                )
+            )
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            viewModel.operationState.value == OperationState.Idle &&
+                destination.resolve("notes.txt").exists()
+        }
+        assertEquals("existing", destination.resolve("report.txt").readText())
+        assertEquals("new upload", destination.resolve("notes.txt").readText())
+        assertEquals(
+            "1 of 2 items could not be uploaded. An item named report.txt already exists in this folder. Rename or remove it, then try again.",
+            viewModel.snackbarMessage.value,
+        )
+    }
+}

--- a/app/src/main/java/com/voyagerfiles/data/remote/ftp/FtpFileProvider.kt
+++ b/app/src/main/java/com/voyagerfiles/data/remote/ftp/FtpFileProvider.kt
@@ -26,30 +26,38 @@ class FtpFileProvider(
 
     private var ftpClient: FTPClient? = null
 
-    private suspend fun ensureConnected() {
-        val client = ftpClient
-        if (client != null && client.isConnected) return
-        withContext(Dispatchers.IO) {
-            val ftp = FTPClient().apply {
-                connectTimeout = 30000
-                defaultTimeout = 30000
-            }
+    private suspend fun ensureConnected() = withContext(Dispatchers.IO) {
+        val existingClient = ftpClient
+        if (existingClient != null) {
+            val connectionIsHealthy = existingClient.isConnected &&
+                runCatching { existingClient.sendNoOp() }.getOrDefault(false)
+            if (connectionIsHealthy) return@withContext
+            runCatching { existingClient.disconnect() }
+            ftpClient = null
+        }
+
+        val ftp = FTPClient().apply {
+            connectTimeout = 30000
+            defaultTimeout = 30000
+        }
+        try {
             ftp.connect(connection.host, connection.port)
 
             val reply = ftp.replyCode
             if (!FTPReply.isPositiveCompletion(reply)) {
-                ftp.disconnect()
                 throw IllegalStateException("FTP server refused connection: $reply")
             }
 
             if (!ftp.login(connection.username, connection.password)) {
-                ftp.disconnect()
                 throw IllegalStateException("FTP login failed")
             }
 
             ftp.enterLocalPassiveMode()
             ftp.setFileType(FTP.BINARY_FILE_TYPE)
             ftpClient = ftp
+        } catch (error: Throwable) {
+            runCatching { if (ftp.isConnected) ftp.disconnect() }
+            throw error
         }
     }
 

--- a/app/src/main/java/com/voyagerfiles/ui/screens/BrowserCreateMenu.kt
+++ b/app/src/main/java/com/voyagerfiles/ui/screens/BrowserCreateMenu.kt
@@ -1,0 +1,60 @@
+package com.voyagerfiles.ui.screens
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.NoteAdd
+import androidx.compose.material.icons.filled.CreateNewFolder
+import androidx.compose.material.icons.filled.UploadFile
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+
+enum class BrowserCreateAction(
+    val label: String,
+    val icon: ImageVector,
+) {
+    NEW_FOLDER("New Folder", Icons.Filled.CreateNewFolder),
+    NEW_FILE("New File", Icons.AutoMirrored.Filled.NoteAdd),
+    UPLOAD_FILES("Upload Files", Icons.Filled.UploadFile),
+}
+
+data class BrowserCreateMenuModel(
+    val actions: List<BrowserCreateAction>,
+) {
+    companion object {
+        fun forState(isRemote: Boolean): BrowserCreateMenuModel =
+            BrowserCreateMenuModel(
+                actions = buildList {
+                    add(BrowserCreateAction.NEW_FOLDER)
+                    add(BrowserCreateAction.NEW_FILE)
+                    if (isRemote) add(BrowserCreateAction.UPLOAD_FILES)
+                },
+            )
+    }
+}
+
+@Composable
+fun BrowserCreateMenu(
+    expanded: Boolean,
+    model: BrowserCreateMenuModel,
+    onDismiss: () -> Unit,
+    onAction: (BrowserCreateAction) -> Unit,
+) {
+    DropdownMenu(
+        expanded = expanded,
+        onDismissRequest = onDismiss,
+    ) {
+        model.actions.forEach { action ->
+            DropdownMenuItem(
+                text = { Text(action.label) },
+                leadingIcon = { Icon(action.icon, null) },
+                onClick = {
+                    onDismiss()
+                    onAction(action)
+                },
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt
+++ b/app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt
@@ -1,6 +1,8 @@
 package com.voyagerfiles.ui.screens
 
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
@@ -134,6 +136,11 @@ fun BrowserScreen(
     val focusManager = LocalFocusManager.current
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
+    val uploadLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenMultipleDocuments(),
+    ) { uris ->
+        viewModel.uploadDocuments(uris)
+    }
 
     var showCreateFolderDialog by remember { mutableStateOf(false) }
     var showCreateFileDialog by remember { mutableStateOf(false) }
@@ -578,7 +585,7 @@ fun BrowserScreen(
                             when (action) {
                                 BrowserCreateAction.NEW_FOLDER -> showCreateFolderDialog = true
                                 BrowserCreateAction.NEW_FILE -> showCreateFileDialog = true
-                                BrowserCreateAction.UPLOAD_FILES -> Unit
+                                BrowserCreateAction.UPLOAD_FILES -> uploadLauncher.launch(arrayOf("*/*"))
                             }
                         },
                     )

--- a/app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt
+++ b/app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.NoteAdd
 import androidx.compose.material.icons.automirrored.filled.Sort
 import androidx.compose.material.icons.automirrored.filled.ViewList
 import androidx.compose.material.icons.filled.BookmarkAdd
@@ -155,6 +154,7 @@ fun BrowserScreen(
     }
     val sharePlan = remember(selectedItems) { ShareIntentPlan.forFiles(selectedItems) }
     val toolbarModel = remember(isNetwork) { BrowserToolbarModel.forState(isNetwork) }
+    val createMenuModel = remember(isNetwork) { BrowserCreateMenuModel.forState(isNetwork) }
     val selectionToolbarModel = remember(isNetwork, selectedItems.size, sharePlan) {
         SelectionToolbarModel.forState(
             isRemote = isNetwork,
@@ -564,35 +564,24 @@ fun BrowserScreen(
         floatingActionButton = {
             if (!isSelectionMode && runningOperation == null) {
                 Box {
-                    if (!isNetwork) {
-                        FloatingActionButton(
-                            onClick = { showCreateMenu = true },
-                            containerColor = MaterialTheme.colorScheme.primaryContainer,
-                        ) {
-                            Icon(Icons.Filled.CreateNewFolder, "Create")
-                        }
-                        DropdownMenu(
-                            expanded = showCreateMenu,
-                            onDismissRequest = { showCreateMenu = false },
-                        ) {
-                            DropdownMenuItem(
-                                text = { Text("New Folder") },
-                                leadingIcon = { Icon(Icons.Filled.CreateNewFolder, null) },
-                                onClick = {
-                                    showCreateMenu = false
-                                    showCreateFolderDialog = true
-                                },
-                            )
-                            DropdownMenuItem(
-                                text = { Text("New File") },
-                                leadingIcon = { Icon(Icons.AutoMirrored.Filled.NoteAdd, null) },
-                                onClick = {
-                                    showCreateMenu = false
-                                    showCreateFileDialog = true
-                                },
-                            )
-                        }
+                    FloatingActionButton(
+                        onClick = { showCreateMenu = true },
+                        containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    ) {
+                        Icon(Icons.Filled.CreateNewFolder, "Create")
                     }
+                    BrowserCreateMenu(
+                        expanded = showCreateMenu,
+                        model = createMenuModel,
+                        onDismiss = { showCreateMenu = false },
+                        onAction = { action ->
+                            when (action) {
+                                BrowserCreateAction.NEW_FOLDER -> showCreateFolderDialog = true
+                                BrowserCreateAction.NEW_FILE -> showCreateFileDialog = true
+                                BrowserCreateAction.UPLOAD_FILES -> Unit
+                            }
+                        },
+                    )
                 }
             }
         },

--- a/app/src/main/java/com/voyagerfiles/util/UploadSourceFactory.kt
+++ b/app/src/main/java/com/voyagerfiles/util/UploadSourceFactory.kt
@@ -1,0 +1,35 @@
+package com.voyagerfiles.util
+
+import android.content.ContentResolver
+import android.net.Uri
+import android.provider.OpenableColumns
+import com.voyagerfiles.viewmodel.UploadSource
+import java.io.IOException
+
+object UploadSourceFactory {
+    fun fromUri(contentResolver: ContentResolver, uri: Uri): UploadSource {
+        val displayName = queryDisplayName(contentResolver, uri)
+            ?: uri.lastPathSegment?.takeIf(String::isNotBlank)
+            ?: throw IOException("Could not determine the selected file name")
+        return UploadSource(displayName) {
+            contentResolver.openInputStream(uri)
+                ?: throw IOException("Could not open $displayName")
+        }
+    }
+
+    private fun queryDisplayName(contentResolver: ContentResolver, uri: Uri): String? =
+        contentResolver.query(
+            uri,
+            arrayOf(OpenableColumns.DISPLAY_NAME),
+            null,
+            null,
+            null,
+        )?.use { cursor ->
+            val nameColumn = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+            if (nameColumn >= 0 && cursor.moveToFirst()) {
+                cursor.getString(nameColumn)?.takeIf(String::isNotBlank)
+            } else {
+                null
+            }
+        }
+}

--- a/app/src/main/java/com/voyagerfiles/viewmodel/FileBrowserViewModel.kt
+++ b/app/src/main/java/com/voyagerfiles/viewmodel/FileBrowserViewModel.kt
@@ -30,6 +30,8 @@ import com.voyagerfiles.ui.theme.AppTheme
 import com.voyagerfiles.util.FileNameValidationResult
 import com.voyagerfiles.util.FileNameValidator
 import com.voyagerfiles.util.FileUtils
+import com.voyagerfiles.util.UploadSourceFactory
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -38,6 +40,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.io.File
 
 class FileBrowserViewModel(application: Application) : AndroidViewModel(application) {
@@ -350,6 +353,50 @@ class FileBrowserViewModel(application: Application) : AndroidViewModel(applicat
                 },
                 onFailure = { showSnackbar(OperationMessages.failure("Create file", it)) },
             )
+        }
+    }
+
+    fun uploadDocuments(uris: List<Uri>) {
+        if (uris.isEmpty()) return
+        val destinationProvider = fileProvider
+        val destinationPath = _browseState.value.currentPath
+        val contentResolver = getApplication<Application>().contentResolver
+        launchOperation(if (uris.size == 1) "Uploading file" else "Uploading ${uris.size} files") {
+            val sources = withContext(Dispatchers.IO) {
+                uris.map { uri -> UploadSourceFactory.fromUri(contentResolver, uri) }
+            }
+            val validatedSources = sources.map { source ->
+                when (val result = FileNameValidator.validate(source.name)) {
+                    is FileNameValidationResult.Valid -> source.copy(name = result.name)
+                    is FileNameValidationResult.Invalid -> throw IllegalArgumentException(result.message)
+                }
+            }
+            var failed = 0
+            var firstError: Throwable? = null
+            for (source in validatedSources) {
+                FileOperationCoordinator.uploadFile(
+                    source = source,
+                    destinationProvider = destinationProvider,
+                    destinationDirectoryPath = destinationPath,
+                ).onFailure { error ->
+                    failed++
+                    if (firstError == null) firstError = error
+                }
+            }
+            refreshFiles()
+            if (failed > 0) {
+                showSnackbar(
+                    OperationMessages.partial(
+                        failed = failed,
+                        total = validatedSources.size,
+                        action = "uploaded",
+                        error = checkNotNull(firstError),
+                    )
+                )
+            } else {
+                val count = validatedSources.size
+                showSnackbar("Uploaded $count file${if (count == 1) "" else "s"}")
+            }
         }
     }
 

--- a/app/src/main/java/com/voyagerfiles/viewmodel/FileOperationCoordinator.kt
+++ b/app/src/main/java/com/voyagerfiles/viewmodel/FileOperationCoordinator.kt
@@ -10,6 +10,37 @@ class DestinationConflictException(val path: String) :
 object FileOperationCoordinator {
     private const val BUFFER_SIZE = 64 * 1024
 
+    suspend fun uploadFile(
+        source: UploadSource,
+        destinationProvider: FileProvider,
+        destinationDirectoryPath: String,
+    ): Result<Unit> = withContext(Dispatchers.IO) {
+        runCatching {
+            val targetPath = joinPath(destinationDirectoryPath, source.name)
+            if (destinationProvider.exists(targetPath)) throw DestinationConflictException(targetPath)
+
+            var targetCreated = false
+            try {
+                source.openInputStream().use { input ->
+                    destinationProvider.getOutputStream(targetPath).getOrThrow().use { output ->
+                        targetCreated = true
+                        input.copyTo(output, BUFFER_SIZE)
+                    }
+                }
+            } catch (error: Throwable) {
+                if (targetCreated) {
+                    runCatching {
+                        if (destinationProvider.exists(targetPath)) {
+                            destinationProvider.delete(targetPath).getOrThrow()
+                        }
+                    }.onFailure(error::addSuppressed)
+                }
+                throw error
+            }
+            Unit
+        }
+    }
+
     suspend fun copyPath(
         sourceProvider: FileProvider,
         destinationProvider: FileProvider,

--- a/app/src/main/java/com/voyagerfiles/viewmodel/UploadSource.kt
+++ b/app/src/main/java/com/voyagerfiles/viewmodel/UploadSource.kt
@@ -1,0 +1,8 @@
+package com.voyagerfiles.viewmodel
+
+import java.io.InputStream
+
+data class UploadSource(
+    val name: String,
+    val openInputStream: () -> InputStream,
+)

--- a/app/src/test/java/com/voyagerfiles/data/remote/ftp/FtpFileProviderTest.kt
+++ b/app/src/test/java/com/voyagerfiles/data/remote/ftp/FtpFileProviderTest.kt
@@ -61,6 +61,21 @@ class FtpFileProviderTest {
     }
 
     @Test
+    fun reconnectsAfterServerDropsTheControlConnection() = runBlocking {
+        val server = startServer()
+        val provider = createProvider(server.port)
+        provider.listFiles("/").getOrThrow()
+        servers.removeAt(servers.lastIndex).stop()
+        startServer(server.root, server.port)
+
+        provider.getOutputStream("/reconnected.txt").getOrThrow().use { stream ->
+            stream.write("reconnected".toByteArray())
+        }
+
+        assertEquals("reconnected", String(Files.readAllBytes(server.root.resolve("reconnected.txt"))))
+    }
+
+    @Test
     fun fileDownloaderSavesFileToLocalDirectory() = runBlocking {
         val server = startServer()
         Files.write(server.root.resolve("remote.txt"), "ftp download".toByteArray())
@@ -146,7 +161,10 @@ class FtpFileProviderTest {
     private fun startServer(): RunningServer {
         val root = temp.newFolder("ftp-root-${servers.size}").toPath()
         val port = freePort()
+        return startServer(root, port)
+    }
 
+    private fun startServer(root: Path, port: Int): RunningServer {
         val user = BaseUser().apply {
             name = USERNAME
             password = PASSWORD

--- a/app/src/test/java/com/voyagerfiles/ui/screens/BrowserCreateMenuModelTest.kt
+++ b/app/src/test/java/com/voyagerfiles/ui/screens/BrowserCreateMenuModelTest.kt
@@ -1,0 +1,30 @@
+package com.voyagerfiles.ui.screens
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class BrowserCreateMenuModelTest {
+
+    @Test
+    fun remoteMenuIncludesCreateAndUploadActions() {
+        assertEquals(
+            listOf(
+                BrowserCreateAction.NEW_FOLDER,
+                BrowserCreateAction.NEW_FILE,
+                BrowserCreateAction.UPLOAD_FILES,
+            ),
+            BrowserCreateMenuModel.forState(isRemote = true).actions,
+        )
+    }
+
+    @Test
+    fun localMenuOmitsUploadAction() {
+        assertEquals(
+            listOf(
+                BrowserCreateAction.NEW_FOLDER,
+                BrowserCreateAction.NEW_FILE,
+            ),
+            BrowserCreateMenuModel.forState(isRemote = false).actions,
+        )
+    }
+}

--- a/app/src/test/java/com/voyagerfiles/viewmodel/FileOperationCoordinatorTest.kt
+++ b/app/src/test/java/com/voyagerfiles/viewmodel/FileOperationCoordinatorTest.kt
@@ -20,6 +20,56 @@ import java.util.concurrent.atomic.AtomicReference
 class FileOperationCoordinatorTest {
 
     @Test
+    fun uploadStreamsSelectedDocumentOffTheCallingThread() = runBlocking {
+        val callerThread = Thread.currentThread().name
+        val openThread = AtomicReference<String?>(null)
+        val writeThread = AtomicReference<String?>(null)
+        val destination = ThreadRecordingProvider(writeThread).apply { putDirectory("/remote") }
+        val source = UploadSource("report.txt") {
+            openThread.set(Thread.currentThread().name)
+            ByteArrayInputStream("report".toByteArray())
+        }
+
+        FileOperationCoordinator.uploadFile(source, destination, "/remote").getOrThrow()
+
+        assertEquals("report", destination.readFile("/remote/report.txt"))
+        assertNotEquals(callerThread, openThread.get())
+        assertNotEquals(callerThread, writeThread.get())
+    }
+
+    @Test
+    fun uploadRefusesExistingFileWithoutOpeningOrOverwritingIt() = runBlocking {
+        var sourceOpened = false
+        val destination = MemoryProvider().apply {
+            putDirectory("/remote")
+            putFile("/remote/report.txt", "existing")
+        }
+        val source = UploadSource("report.txt") {
+            sourceOpened = true
+            ByteArrayInputStream("replacement".toByteArray())
+        }
+
+        val result = FileOperationCoordinator.uploadFile(source, destination, "/remote")
+
+        assertTrue(result.exceptionOrNull() is DestinationConflictException)
+        assertFalse(sourceOpened)
+        assertEquals("existing", destination.readFile("/remote/report.txt"))
+    }
+
+    @Test
+    fun failedUploadRemovesPartialTarget() = runBlocking {
+        val destination = FailingWriteProvider().apply { putDirectory("/remote") }
+        val source = UploadSource("report.txt") {
+            ByteArrayInputStream("report".toByteArray())
+        }
+
+        val result = FileOperationCoordinator.uploadFile(source, destination, "/remote")
+
+        assertTrue(result.isFailure)
+        assertFalse(destination.exists("/remote/report.txt"))
+    }
+
+    @Test
     fun copyStreamsFileBetweenDifferentProviders() = runBlocking {
         val source = MemoryProvider().apply { putFile("/local/report.txt", "report") }
         val destination = MemoryProvider().apply { putDirectory("/remote") }

--- a/docs/superpowers/plans/2026-07-19-remote-create-upload.md
+++ b/docs/superpowers/plans/2026-07-19-remote-create-upload.md
@@ -1,0 +1,244 @@
+# Remote Create and Upload Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore remote folder and file creation and add direct multi-file upload from Android's document picker.
+
+**Architecture:** BrowserScreen will render an explicit provider-aware Create menu and launch OpenMultipleDocuments for Upload Files. FileBrowserViewModel will resolve selected URIs into validated lazy stream sources, then FileOperationCoordinator will stream each source to the active provider with conflict protection, I/O dispatching, partial-file cleanup, and batch result reporting.
+
+**Tech Stack:** Kotlin 2.1, Jetpack Compose Material 3, Android Activity Result API, Android ContentResolver, Kotlin coroutines, JUnit 4, AndroidX Compose UI tests.
+
+## Global Constraints
+
+- Show New Folder and New File in local, SAF, FTP, SFTP, SMB, and WebDAV browser sessions.
+- Show Upload Files only for network sessions.
+- Stream selected documents with a 64 KiB buffer and never load a whole file into memory.
+- Refuse destination conflicts and preserve existing content.
+- Validate every selected display name before starting any transfer.
+- Run resolver and stream I/O on Dispatchers.IO.
+- Keep prose in Markdown as one paragraph per physical line and do not add AI-authorship markers.
+
+---
+
+### Task 1: Stream a selected document into a provider
+
+**Files:**
+- Create: `app/src/main/java/com/voyagerfiles/viewmodel/UploadSource.kt`
+- Modify: `app/src/main/java/com/voyagerfiles/viewmodel/FileOperationCoordinator.kt`
+- Test: `app/src/test/java/com/voyagerfiles/viewmodel/FileOperationCoordinatorTest.kt`
+
+**Interfaces:**
+- Consumes: `FileProvider.exists(path)`, `FileProvider.getOutputStream(path)`, and `FileProvider.delete(path)`.
+- Produces: `data class UploadSource(val name: String, val openInputStream: () -> InputStream)` and `suspend fun FileOperationCoordinator.uploadFile(source: UploadSource, destinationProvider: FileProvider, destinationDirectoryPath: String): Result<Unit>`.
+
+- [ ] **Step 1: Write failing coordinator tests**
+
+Add tests that upload `report.txt` from a ByteArrayInputStream, assert that the destination contains the exact bytes, record the write thread and assert it differs from the caller thread, pre-create `/remote/report.txt` and assert DestinationConflictException without overwrite, and use FailingWriteProvider to assert a partial `/remote/report.txt` is removed while the source factory remains reusable.
+
+```kotlin
+@Test
+fun uploadStreamsSelectedDocumentOffTheCallingThread() = runBlocking {
+    val callerThread = Thread.currentThread().name
+    val writeThread = AtomicReference<String?>(null)
+    val destination = ThreadRecordingProvider(writeThread).apply { putDirectory("/remote") }
+    val source = UploadSource("report.txt") { ByteArrayInputStream("report".toByteArray()) }
+
+    FileOperationCoordinator.uploadFile(source, destination, "/remote").getOrThrow()
+
+    assertEquals("report", destination.readFile("/remote/report.txt"))
+    assertNotEquals(callerThread, writeThread.get())
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.viewmodel.FileOperationCoordinatorTest --stacktrace`
+
+Expected: compilation fails because UploadSource and uploadFile do not exist.
+
+- [ ] **Step 3: Add UploadSource and the minimal streaming implementation**
+
+```kotlin
+data class UploadSource(
+    val name: String,
+    val openInputStream: () -> InputStream,
+)
+```
+
+Implement uploadFile with `withContext(Dispatchers.IO)`, the existing joinPath helper, an `exists` conflict check, `use` blocks around both streams, `copyTo(output, BUFFER_SIZE)`, and the same guarded target deletion used by copyPathInternal.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.viewmodel.FileOperationCoordinatorTest --stacktrace`
+
+Expected: all FileOperationCoordinatorTest cases pass.
+
+- [ ] **Step 5: Commit the coordinator boundary**
+
+```bash
+git add app/src/main/java/com/voyagerfiles/viewmodel/UploadSource.kt app/src/main/java/com/voyagerfiles/viewmodel/FileOperationCoordinator.kt app/src/test/java/com/voyagerfiles/viewmodel/FileOperationCoordinatorTest.kt
+git commit -m "feat: stream document uploads to providers"
+```
+
+### Task 2: Model and render provider-aware Create actions
+
+**Files:**
+- Create: `app/src/main/java/com/voyagerfiles/ui/screens/BrowserCreateMenu.kt`
+- Create: `app/src/test/java/com/voyagerfiles/ui/screens/BrowserCreateMenuModelTest.kt`
+- Create: `app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserCreateMenuTest.kt`
+- Modify: `app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt`
+
+**Interfaces:**
+- Consumes: `isNetwork` from BrowseState's FileSource.
+- Produces: `BrowserCreateAction`, `BrowserCreateMenuModel.forState(isRemote: Boolean)`, and `BrowserCreateMenu(expanded, model, onDismiss, onAction)`.
+
+- [ ] **Step 1: Write failing menu-model and Compose tests**
+
+```kotlin
+@Test
+fun remoteMenuIncludesCreateAndUploadActions() {
+    assertEquals(
+        listOf(NEW_FOLDER, NEW_FILE, UPLOAD_FILES),
+        BrowserCreateMenuModel.forState(isRemote = true).actions,
+    )
+}
+
+@Test
+fun localMenuOmitsUploadAction() {
+    assertEquals(
+        listOf(NEW_FOLDER, NEW_FILE),
+        BrowserCreateMenuModel.forState(isRemote = false).actions,
+    )
+}
+```
+
+The Compose test renders BrowserCreateMenu expanded with the remote model and asserts that New Folder, New File, and Upload Files are displayed.
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.ui.screens.BrowserCreateMenuModelTest --stacktrace`
+
+Expected: compilation fails because the menu model does not exist.
+
+- [ ] **Step 3: Implement the menu model and composable**
+
+```kotlin
+enum class BrowserCreateAction { NEW_FOLDER, NEW_FILE, UPLOAD_FILES }
+
+data class BrowserCreateMenuModel(val actions: List<BrowserCreateAction>) {
+    companion object {
+        fun forState(isRemote: Boolean) = BrowserCreateMenuModel(
+            buildList {
+                add(BrowserCreateAction.NEW_FOLDER)
+                add(BrowserCreateAction.NEW_FILE)
+                if (isRemote) add(BrowserCreateAction.UPLOAD_FILES)
+            },
+        )
+    }
+}
+```
+
+BrowserCreateMenu maps the three actions to the existing CreateNewFolder and NoteAdd icons plus an UploadFile icon, closes through onDismiss, and reports the selected enum through onAction. BrowserScreen replaces the `if (!isNetwork)` block with the menu model and retains the existing dialog callbacks for New Folder and New File.
+
+- [ ] **Step 4: Run unit and instrumented menu tests and verify GREEN**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.ui.screens.BrowserCreateMenuModelTest --stacktrace`
+
+Run: `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.voyagerfiles.ui.screens.BrowserCreateMenuTest --stacktrace`
+
+Expected: both commands pass and the device test reports one passing test.
+
+- [ ] **Step 5: Commit the provider-aware Create menu**
+
+```bash
+git add app/src/main/java/com/voyagerfiles/ui/screens/BrowserCreateMenu.kt app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt app/src/test/java/com/voyagerfiles/ui/screens/BrowserCreateMenuModelTest.kt app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserCreateMenuTest.kt
+git commit -m "fix: expose create actions for remote sessions"
+```
+
+### Task 3: Resolve document URIs and upload a validated batch
+
+**Files:**
+- Create: `app/src/main/java/com/voyagerfiles/util/UploadSourceFactory.kt`
+- Modify: `app/src/main/java/com/voyagerfiles/viewmodel/FileBrowserViewModel.kt`
+- Modify: `app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt`
+- Create: `app/src/androidTest/java/com/voyagerfiles/viewmodel/DocumentUploadTest.kt`
+
+**Interfaces:**
+- Consumes: `UploadSource`, `FileOperationCoordinator.uploadFile`, `FileNameValidator`, and `ActivityResultContracts.OpenMultipleDocuments`.
+- Produces: `UploadSourceFactory.fromUri(contentResolver: ContentResolver, uri: Uri): UploadSource` and `FileBrowserViewModel.uploadDocuments(uris: List<Uri>)`.
+
+- [ ] **Step 1: Write a failing end-to-end Android upload test**
+
+Create a source file in the application cache, expose it with the existing FileProvider authority, open a separate local destination root in FileBrowserViewModel, call uploadDocuments with the URI, wait for OperationState.Idle, and assert that the destination file has the source name and exact contents.
+
+```kotlin
+val sourceUri = FileProvider.getUriForFile(application, "${application.packageName}.fileprovider", sourceFile)
+viewModel.openLocalRoot(destination.absolutePath)
+viewModel.uploadDocuments(listOf(sourceUri))
+composeTestRule.waitUntil(10_000) { destination.resolve(sourceFile.name).exists() }
+assertEquals(sourceFile.readText(), destination.resolve(sourceFile.name).readText())
+```
+
+- [ ] **Step 2: Run the focused device test and verify RED**
+
+Run: `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.voyagerfiles.viewmodel.DocumentUploadTest --stacktrace`
+
+Expected: compilation fails because uploadDocuments does not exist.
+
+- [ ] **Step 3: Implement URI resolution and batch upload**
+
+UploadSourceFactory queries OpenableColumns.DISPLAY_NAME, falls back to the URI's last path segment as required by the Android OpenableColumns contract, and creates a lazy input-stream factory that throws IOException when ContentResolver returns null.
+
+FileBrowserViewModel.uploadDocuments returns for an empty selection, captures the active provider and destination path, resolves all URIs on Dispatchers.IO, validates every name before transferring any file, uploads sequentially through FileOperationCoordinator, refreshes once, reports `Uploaded N file` or `Uploaded N files` on complete success, and uses OperationMessages.partial with action `uploaded` and the first error when any source fails.
+
+BrowserScreen registers `rememberLauncherForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { viewModel.uploadDocuments(it) }` and launches it with `arrayOf("*/*")` when BrowserCreateAction.UPLOAD_FILES is selected.
+
+- [ ] **Step 4: Run focused unit and device tests and verify GREEN**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.viewmodel.FileOperationCoordinatorTest --tests com.voyagerfiles.ui.screens.BrowserCreateMenuModelTest --stacktrace`
+
+Run: `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.voyagerfiles.viewmodel.DocumentUploadTest,com.voyagerfiles.ui.screens.BrowserCreateMenuTest --stacktrace`
+
+Expected: all focused tests pass and the uploaded file contents match exactly.
+
+- [ ] **Step 5: Commit picker integration**
+
+```bash
+git add app/src/main/java/com/voyagerfiles/util/UploadSourceFactory.kt app/src/main/java/com/voyagerfiles/viewmodel/FileBrowserViewModel.kt app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt app/src/androidTest/java/com/voyagerfiles/viewmodel/DocumentUploadTest.kt
+git commit -m "feat: upload selected documents to remote sessions"
+```
+
+### Task 4: Verify the complete issue fix
+
+**Files:**
+- Modify only if verification finds a defect in files already listed above.
+
+**Interfaces:**
+- Consumes: all production and test interfaces introduced in Tasks 1 through 3.
+- Produces: a clean branch with reproducible local, device, and CI evidence.
+
+- [ ] **Step 1: Run the complete local gate**
+
+Run: `./gradlew testDebugUnitTest lintDebug assembleDebug assembleRelease --stacktrace`
+
+Expected: BUILD SUCCESSFUL with no test or lint failures.
+
+- [ ] **Step 2: Run the complete connected test suite**
+
+Run: `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew connectedDebugAndroidTest --stacktrace`
+
+Expected: all instrumented tests pass on the connected Android 16 device.
+
+- [ ] **Step 3: Exercise the FTP workflow on device**
+
+Start a temporary authenticated pyftpdlib server with `uv run --with pyftpdlib python -m pyftpdlib`, connect the debug app to the workstation's LAN address, create a folder through the remote Create menu, upload a known file through the system picker, and verify the server root contains both the new directory and an uploaded file with byte-for-byte matching contents. Keep the server root under a `mktemp -d` directory and remove the temporary server, debug app, device fixture, and directory after verification.
+
+- [ ] **Step 4: Audit the branch**
+
+Run: `git diff --check master...HEAD && git status --short && git log --oneline master..HEAD`
+
+Expected: no whitespace errors, no uncommitted files, and only the design, plan, coordinator, menu, picker, and tests for issue #23.
+
+- [ ] **Step 5: Publish for CI**
+
+Push `codex/ftp-create-upload`, open a focused pull request with `Fixes #23`, wait for Android CI, and merge only after GitHub reports the branch mergeable and every required check successful.

--- a/docs/superpowers/plans/2026-07-19-remote-create-upload.md
+++ b/docs/superpowers/plans/2026-07-19-remote-create-upload.md
@@ -16,6 +16,7 @@
 - Refuse destination conflicts and preserve existing content.
 - Validate every selected display name before starting any transfer.
 - Run resolver and stream I/O on Dispatchers.IO.
+- Validate an existing FTP control connection with NOOP and reconnect before reuse when the peer has closed it.
 - Keep prose in Markdown as one paragraph per physical line and do not add AI-authorship markers.
 
 ---
@@ -208,13 +209,50 @@ git add app/src/main/java/com/voyagerfiles/util/UploadSourceFactory.kt app/src/m
 git commit -m "feat: upload selected documents to remote sessions"
 ```
 
-### Task 4: Verify the complete issue fix
+### Task 4: Recover an FTP session after the document picker
+
+**Files:**
+- Modify: `app/src/main/java/com/voyagerfiles/data/remote/ftp/FtpFileProvider.kt`
+- Test: `app/src/test/java/com/voyagerfiles/data/remote/ftp/FtpFileProviderTest.kt`
+
+**Interfaces:**
+- Consumes: Apache Commons Net `FTPClient.sendNoOp()`, `FTPClient.disconnect()`, and the existing FTP login sequence.
+- Produces: `FtpFileProvider.ensureConnected()` that validates and replaces a stale control connection before provider operations.
+
+- [ ] **Step 1: Write a failing dropped-connection test**
+
+Connect a provider to the in-process FTP server, stop that server while retaining the provider, restart a server on the same port and root, then request an output stream and assert that the uploaded bytes arrive through a replacement connection.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.data.remote.ftp.FtpFileProviderTest.reconnectsAfterServerDropsTheControlConnection --stacktrace`
+
+Expected: FAIL with FTPConnectionClosedException because `isConnected` does not prove the peer socket is usable.
+
+- [ ] **Step 3: Validate and replace stale clients**
+
+In ensureConnected, call sendNoOp for a non-null connected client. Return only when NOOP succeeds. Otherwise disconnect that client, clear the field, and run the existing connect, reply validation, login, passive-mode, and binary-mode sequence. Disconnect a partially initialized replacement if setup throws.
+
+- [ ] **Step 4: Run all FTP provider tests and verify GREEN**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.data.remote.ftp.FtpFileProviderTest --stacktrace`
+
+Expected: all FTP provider tests pass, including the dropped-control-connection regression.
+
+- [ ] **Step 5: Commit stale-session recovery**
+
+```bash
+git add app/src/main/java/com/voyagerfiles/data/remote/ftp/FtpFileProvider.kt app/src/test/java/com/voyagerfiles/data/remote/ftp/FtpFileProviderTest.kt docs/superpowers/specs/2026-07-19-remote-create-upload-design.md docs/superpowers/plans/2026-07-19-remote-create-upload.md
+git commit -m "fix: reconnect stale FTP sessions"
+```
+
+### Task 5: Verify the complete issue fix
 
 **Files:**
 - Modify only if verification finds a defect in files already listed above.
 
 **Interfaces:**
-- Consumes: all production and test interfaces introduced in Tasks 1 through 3.
+- Consumes: all production and test interfaces introduced in Tasks 1 through 4.
 - Produces: a clean branch with reproducible local, device, and CI evidence.
 
 - [ ] **Step 1: Run the complete local gate**

--- a/docs/superpowers/specs/2026-07-19-remote-create-upload-design.md
+++ b/docs/superpowers/specs/2026-07-19-remote-create-upload-design.md
@@ -14,6 +14,7 @@ Voyager 1.4.0 hides the Create floating action button whenever a browser session
 - Remove a partially created destination when a transfer fails where the provider permits cleanup.
 - Validate document display names before constructing remote paths.
 - Keep provider operations and stream copying off the Android main thread.
+- Reconnect FTP when the system picker outlives the existing control connection.
 - Report complete success, complete failure, and partial success, then refresh the active directory.
 
 ## Considered Approaches
@@ -38,6 +39,8 @@ UploadSource contains a display name and a lazy InputStream factory. The view mo
 
 FileOperationCoordinator will add uploadFile. The method switches to Dispatchers.IO, joins the validated name to the destination directory, refuses a conflicting target with DestinationConflictException, opens the selected document and destination streams, copies with the existing 64 KiB buffer, and attempts to delete a partially created target after failure. The input stream is opened inside the I/O context.
 
+FtpFileProvider will validate an existing control connection with the FTP NOOP command before reuse. If the peer closed the socket while Voyager was in the system picker, the provider disconnects the stale client and authenticates a replacement before issuing the upload command.
+
 The view model will refresh once after all sources have been attempted. A complete success reports the uploaded file count. A partial or complete failure uses the existing OperationMessages.partial format and includes the first underlying error. The normal operation state disables additional create or upload actions until completion.
 
 ## Testing
@@ -46,6 +49,7 @@ The view model will refresh once after all sources have been attempted. A comple
 - Unit-test that uploadFile streams bytes to the requested destination on a non-calling thread.
 - Unit-test that uploadFile refuses an existing target without modifying it.
 - Unit-test that uploadFile deletes a partially written target after a stream failure.
+- Unit-test that the FTP provider reconnects and uploads after the server drops the original control connection.
 - Add an instrumented UI test that opens a remote-mode Create menu model or composable and verifies the three user-facing actions if practical without a live server.
 - Run the full unit, lint, debug assembly, and release assembly gate.
 - Exercise the picker and upload flow on the connected Android device against a local FTP fixture if the device can reach the fixture; otherwise verify the picker UI on device and cover provider transfer behavior with the existing in-process FTP and coordinator tests.

--- a/docs/superpowers/specs/2026-07-19-remote-create-upload-design.md
+++ b/docs/superpowers/specs/2026-07-19-remote-create-upload-design.md
@@ -1,0 +1,57 @@
+# Remote Create and Upload Design
+
+## Problem
+
+Voyager 1.4.0 hides the Create floating action button whenever a browser session uses a network provider. This prevents users from reaching the existing New Folder and New File commands even though the FTP, SFTP, SMB, and WebDAV providers implement both operations. Remote sessions also lack a direct document-picker entry point for uploading files, so users must discover the cross-session clipboard workflow.
+
+## Requirements
+
+- Show New Folder and New File in local, SAF, FTP, SFTP, SMB, and WebDAV browser sessions.
+- Show Upload Files only for network sessions.
+- Allow one or more documents to be selected with Android's system document picker.
+- Stream each selected document directly to the active provider without loading the whole file into memory.
+- Preserve an existing destination file instead of overwriting it.
+- Remove a partially created destination when a transfer fails where the provider permits cleanup.
+- Validate document display names before constructing remote paths.
+- Keep provider operations and stream copying off the Android main thread.
+- Report complete success, complete failure, and partial success, then refresh the active directory.
+
+## Considered Approaches
+
+### Reuse only the clipboard workflow
+
+Removing the remote-only UI guard would restore folder and empty-file creation, and the existing Copy, Sessions, and Paste here workflow can already stream local files to FTP. This is the smallest code change, but it leaves the reported upload discoverability problem unresolved.
+
+### Stage selected documents in app storage
+
+The app could copy picker results into a cache directory and then reuse a local FileProvider. This would duplicate large files, require temporary-space management, and delay the actual upload without adding useful behavior.
+
+### Stream document-picker results to the active provider
+
+The browser can use ActivityResultContracts.OpenMultipleDocuments, resolve each URI's OpenableColumns.DISPLAY_NAME, and pass a lazy input-stream source to the view model. The operation coordinator can apply the same conflict and partial-file cleanup semantics used by cross-provider copies. This adds a direct upload path while retaining bounded memory use and is the selected approach.
+
+## Design
+
+BrowserScreen will model the Create menu explicitly. Local and SAF sessions receive New Folder and New File. Network sessions receive those actions plus Upload Files. Selecting Upload Files launches ActivityResultContracts.OpenMultipleDocuments with a wildcard MIME filter, converts each returned URI into an UploadSource using ContentResolver, and submits the sources to FileBrowserViewModel.
+
+UploadSource contains a display name and a lazy InputStream factory. The view model validates every name with FileNameValidator before starting the operation. It then uploads sources sequentially to the provider and directory captured when the operation starts. Sequential transfer avoids concurrent use of provider clients that are not designed for parallel commands and makes partial-failure accounting deterministic.
+
+FileOperationCoordinator will add uploadFile. The method switches to Dispatchers.IO, joins the validated name to the destination directory, refuses a conflicting target with DestinationConflictException, opens the selected document and destination streams, copies with the existing 64 KiB buffer, and attempts to delete a partially created target after failure. The input stream is opened inside the I/O context.
+
+The view model will refresh once after all sources have been attempted. A complete success reports the uploaded file count. A partial or complete failure uses the existing OperationMessages.partial format and includes the first underlying error. The normal operation state disables additional create or upload actions until completion.
+
+## Testing
+
+- Unit-test that the remote Create menu exposes New Folder, New File, and Upload Files while the local menu omits Upload Files.
+- Unit-test that uploadFile streams bytes to the requested destination on a non-calling thread.
+- Unit-test that uploadFile refuses an existing target without modifying it.
+- Unit-test that uploadFile deletes a partially written target after a stream failure.
+- Add an instrumented UI test that opens a remote-mode Create menu model or composable and verifies the three user-facing actions if practical without a live server.
+- Run the full unit, lint, debug assembly, and release assembly gate.
+- Exercise the picker and upload flow on the connected Android device against a local FTP fixture if the device can reach the fixture; otherwise verify the picker UI on device and cover provider transfer behavior with the existing in-process FTP and coordinator tests.
+
+## Non-goals
+
+- Directory-tree upload is not included because OpenMultipleDocuments returns files, not a portable recursive directory tree.
+- Overwrite prompts and rename-on-conflict policies are not included. Existing destination content remains protected.
+- Upload progress by byte count is not included; the existing operation-level progress indicator remains in use.


### PR DESCRIPTION
Fixes #23.

## What changed

- Show New Folder and New File in FTP, SFTP, SMB, and WebDAV sessions.
- Add a remote-only Upload Files command backed by Android's multi-document picker.
- Stream selected documents to the active provider with bounded memory, filename validation, conflict protection, partial-failure reporting, and partial-target cleanup.
- Validate FTP control connections with NOOP and reconnect when the system picker outlives the prior socket.

## Root causes

BrowserScreen suppressed the entire Create menu for every network provider even though each provider implements file and directory creation. Voyager also had no document-picker upload entry point. During live FTP verification, the picker exposed a second failure: FTPClient.isConnected remained true after the peer closed an idle control socket, so the provider reused a stale client and returned Broken pipe.

## User impact

Remote sessions now expose the same folder and empty-file creation commands as local sessions plus direct multi-file upload. Existing destination files are not overwritten. FTP uploads recover from a stale control connection after returning from the picker.

## Validation

- `./gradlew testDebugUnitTest lintDebug assembleDebug assembleRelease --rerun-tasks --stacktrace`: 103 tasks executed, successful.
- `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew connectedDebugAndroidTest --rerun-tasks --stacktrace`: 18 tests passed on Android 16, 0 failed.
- Focused red-green coverage for provider streaming, destination conflicts, partial-target cleanup, remote menu contents, content-URI upload, batch partial failure, and dropped FTP control connections.
- Live authenticated FTP check from the physical device: remote folder creation succeeded; after the original picker-idle control connection closed, Voyager reconnected and uploaded an 84-byte document. Source and server SHA-256 both matched `fbd56779899184eacaab53d82889bedbe5d2512a8d717896b5ed5a2028024399`.
