### PR TITLE
Close inactive sessions after a configurable timeout

### DIFF
--- a/app/src/androidTest/java/com/voyagerfiles/ui/screens/SessionAutoCloseNavigationTest.kt
+++ b/app/src/androidTest/java/com/voyagerfiles/ui/screens/SessionAutoCloseNavigationTest.kt
@@ -1,0 +1,89 @@
+package com.voyagerfiles.ui.screens
+
+import android.app.Application
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.voyagerfiles.data.local.PreferencesManager
+import com.voyagerfiles.data.model.SessionAutoCloseTimeout
+import com.voyagerfiles.viewmodel.FileBrowserViewModel
+import java.io.File
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class SessionAutoCloseNavigationTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var application: Application
+    private lateinit var preferences: PreferencesManager
+    private lateinit var root: File
+
+    @Before
+    fun setUp() {
+        application = ApplicationProvider.getApplicationContext()
+        preferences = PreferencesManager(application)
+        runBlocking {
+            preferences.setAutoCloseSessions(true)
+            preferences.setSessionAutoCloseTimeout(SessionAutoCloseTimeout.FIVE_MINUTES)
+        }
+        root = File(application.cacheDir, "session-auto-close-navigation-test").apply {
+            deleteRecursively()
+            mkdirs()
+        }
+    }
+
+    @After
+    fun tearDown() {
+        root.deleteRecursively()
+        runBlocking {
+            preferences.setAutoCloseSessions(false)
+            preferences.setSessionAutoCloseTimeout(SessionAutoCloseTimeout.FIFTEEN_MINUTES)
+        }
+    }
+
+    @Test
+    fun automaticClosureReturnsAnOpenBrowserToHome() {
+        val viewModel = FileBrowserViewModel(application)
+        composeTestRule.setContent {
+            MaterialTheme {
+                AppNavigation(
+                    viewModel = viewModel,
+                    hasAllFilesAccess = true,
+                    onRequestAllFilesAccess = {},
+                )
+            }
+        }
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            viewModel.autoCloseSessions.value
+        }
+        composeTestRule.runOnIdle { viewModel.openLocalRoot(root.absolutePath) }
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            viewModel.sessions.value.size == 1 && !viewModel.browseState.value.isLoading
+        }
+        composeTestRule.onNodeWithText(root.name).assertIsDisplayed().performClick()
+        composeTestRule.onNodeWithContentDescription("Back").assertIsDisplayed()
+        val previousGeneration = viewModel.sessionClosureGeneration.value
+
+        composeTestRule.runOnIdle {
+            viewModel.onAppBackgrounded(nowMillis = 1_000L)
+            viewModel.onAppForegrounded(
+                nowMillis = 1_000L + SessionAutoCloseTimeout.FIVE_MINUTES.durationMillis,
+            )
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            viewModel.sessionClosureGeneration.value == previousGeneration + 1L
+        }
+        composeTestRule.onNodeWithText("Voyager").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Settings").assertIsDisplayed()
+    }
+}

--- a/app/src/androidTest/java/com/voyagerfiles/ui/screens/SessionAutoCloseNavigationTest.kt
+++ b/app/src/androidTest/java/com/voyagerfiles/ui/screens/SessionAutoCloseNavigationTest.kt
@@ -26,6 +26,7 @@ class SessionAutoCloseNavigationTest {
     private lateinit var application: Application
     private lateinit var preferences: PreferencesManager
     private lateinit var root: File
+    private lateinit var returningRoot: File
 
     @Before
     fun setUp() {
@@ -39,11 +40,16 @@ class SessionAutoCloseNavigationTest {
             deleteRecursively()
             mkdirs()
         }
+        returningRoot = File(application.cacheDir, "session-auto-close-returning-test").apply {
+            deleteRecursively()
+            mkdirs()
+        }
     }
 
     @After
     fun tearDown() {
         root.deleteRecursively()
+        returningRoot.deleteRecursively()
         runBlocking {
             preferences.setAutoCloseSessions(false)
             preferences.setSessionAutoCloseTimeout(SessionAutoCloseTimeout.FIFTEEN_MINUTES)
@@ -85,5 +91,51 @@ class SessionAutoCloseNavigationTest {
         }
         composeTestRule.onNodeWithText("Voyager").assertIsDisplayed()
         composeTestRule.onNodeWithContentDescription("Settings").assertIsDisplayed()
+    }
+
+    @Test
+    fun sessionCreatedByReturningPickerResultRemainsOpen() {
+        val viewModel = FileBrowserViewModel(application)
+        composeTestRule.setContent {
+            MaterialTheme {
+                AppNavigation(
+                    viewModel = viewModel,
+                    hasAllFilesAccess = true,
+                    onRequestAllFilesAccess = {},
+                )
+            }
+        }
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            viewModel.autoCloseSessions.value
+        }
+        composeTestRule.runOnIdle { viewModel.openLocalRoot(root.absolutePath) }
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            viewModel.sessions.value.size == 1 && !viewModel.browseState.value.isLoading
+        }
+        composeTestRule.onNodeWithText(root.name).assertIsDisplayed().performClick()
+        composeTestRule.onNodeWithContentDescription("Back").assertIsDisplayed()
+        val previousGeneration = viewModel.sessionClosureGeneration.value
+
+        composeTestRule.runOnIdle {
+            viewModel.onAppBackgrounded(nowMillis = 1_000L)
+            viewModel.openLocalRoot(returningRoot.absolutePath)
+        }
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            viewModel.sessions.value.size == 2 &&
+                viewModel.activeSession.value?.rootPath == returningRoot.absolutePath &&
+                !viewModel.browseState.value.isLoading
+        }
+        composeTestRule.runOnIdle {
+            viewModel.onAppForegrounded(
+                nowMillis = 1_000L + SessionAutoCloseTimeout.FIVE_MINUTES.durationMillis,
+            )
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            viewModel.sessionClosureGeneration.value == previousGeneration + 1L &&
+                viewModel.sessions.value.singleOrNull()?.rootPath == returningRoot.absolutePath
+        }
+        composeTestRule.onNodeWithContentDescription("Back").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Voyager").assertDoesNotExist()
     }
 }

--- a/app/src/androidTest/java/com/voyagerfiles/ui/screens/SessionAutoCloseSettingsTest.kt
+++ b/app/src/androidTest/java/com/voyagerfiles/ui/screens/SessionAutoCloseSettingsTest.kt
@@ -1,0 +1,90 @@
+package com.voyagerfiles.ui.screens
+
+import android.app.Application
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.test.core.app.ApplicationProvider
+import com.voyagerfiles.data.local.PreferencesManager
+import com.voyagerfiles.data.model.SessionAutoCloseTimeout
+import com.voyagerfiles.viewmodel.FileBrowserViewModel
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class SessionAutoCloseSettingsTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var application: Application
+    private lateinit var preferences: PreferencesManager
+
+    @Before
+    fun setUp() {
+        application = ApplicationProvider.getApplicationContext()
+        preferences = PreferencesManager(application)
+        runBlocking {
+            preferences.setAutoCloseSessions(false)
+            preferences.setSessionAutoCloseTimeout(SessionAutoCloseTimeout.FIFTEEN_MINUTES)
+        }
+    }
+
+    @After
+    fun tearDown() {
+        runBlocking {
+            preferences.setAutoCloseSessions(false)
+            preferences.setSessionAutoCloseTimeout(SessionAutoCloseTimeout.FIFTEEN_MINUTES)
+        }
+    }
+
+    @Test
+    fun settingEnablesAutoCloseAndPersistsSelectedTimeout() {
+        val viewModel = FileBrowserViewModel(application)
+        composeTestRule.setContent {
+            MaterialTheme {
+                SettingsScreen(
+                    viewModel = viewModel,
+                    onNavigateBack = {},
+                    hasAllFilesAccess = false,
+                    onRequestAllFilesAccess = {},
+                )
+            }
+        }
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            !viewModel.autoCloseSessions.value &&
+                viewModel.sessionAutoCloseTimeout.value == SessionAutoCloseTimeout.FIFTEEN_MINUTES
+        }
+
+        composeTestRule.onNodeWithContentDescription("Auto-close sessions")
+            .performScrollTo()
+            .assertIsOff()
+            .performClick()
+            .assertIsOn()
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            viewModel.autoCloseSessions.value
+        }
+        composeTestRule.onNodeWithContentDescription("Session timeout, current 15 minutes")
+            .performScrollTo()
+            .assertIsDisplayed()
+            .performClick()
+        composeTestRule.onNodeWithText("5 minutes").assertIsDisplayed().performClick()
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            viewModel.sessionAutoCloseTimeout.value == SessionAutoCloseTimeout.FIVE_MINUTES
+        }
+
+        val restoredViewModel = FileBrowserViewModel(application)
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            restoredViewModel.autoCloseSessions.value &&
+                restoredViewModel.sessionAutoCloseTimeout.value == SessionAutoCloseTimeout.FIVE_MINUTES
+        }
+    }
+}

--- a/app/src/androidTest/java/com/voyagerfiles/viewmodel/SessionAutoCloseTest.kt
+++ b/app/src/androidTest/java/com/voyagerfiles/viewmodel/SessionAutoCloseTest.kt
@@ -84,6 +84,7 @@ class SessionAutoCloseTest {
         assertNull(viewModel.activeSession.value)
         assertTrue(viewModel.clipboardPaths.value.isEmpty())
         assertEquals(ClipboardOperation.NONE, viewModel.clipboardOperation.value)
+        assertNull(viewModel.snackbarMessage.value)
         assertEquals(FileSource.LOCAL, viewModel.browseState.value.source)
         assertTrue(viewModel.browseState.value.files.isEmpty())
     }

--- a/app/src/androidTest/java/com/voyagerfiles/viewmodel/SessionAutoCloseTest.kt
+++ b/app/src/androidTest/java/com/voyagerfiles/viewmodel/SessionAutoCloseTest.kt
@@ -87,4 +87,38 @@ class SessionAutoCloseTest {
         assertEquals(FileSource.LOCAL, viewModel.browseState.value.source)
         assertTrue(viewModel.browseState.value.files.isEmpty())
     }
+
+    @Test
+    fun expiredIntervalWaitsForAnActiveOperationToFinish() {
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        val viewModel = FileBrowserViewModel(application)
+        composeTestRule.setContent {}
+        composeTestRule.runOnIdle {
+            viewModel.openLocalRoot(root.absolutePath)
+            viewModel.setAutoCloseSessions(true)
+        }
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            viewModel.autoCloseSessions.value &&
+                viewModel.sessions.value.size == 1 &&
+                !viewModel.browseState.value.isLoading
+        }
+        val previousGeneration = viewModel.sessionClosureGeneration.value
+
+        composeTestRule.runOnIdle {
+            viewModel.createFile("completed-before-close.txt")
+            assertTrue(viewModel.operationState.value is OperationState.Running)
+            viewModel.onAppBackgrounded(nowMillis = 1_000L)
+            viewModel.onAppForegrounded(
+                nowMillis = 1_000L + SessionAutoCloseTimeout.FIVE_MINUTES.durationMillis,
+            )
+            assertEquals(1, viewModel.sessions.value.size)
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            viewModel.operationState.value == OperationState.Idle &&
+                viewModel.sessions.value.isEmpty() &&
+                viewModel.sessionClosureGeneration.value == previousGeneration + 1L
+        }
+        assertTrue(root.resolve("completed-before-close.txt").exists())
+    }
 }

--- a/app/src/androidTest/java/com/voyagerfiles/viewmodel/SessionAutoCloseTest.kt
+++ b/app/src/androidTest/java/com/voyagerfiles/viewmodel/SessionAutoCloseTest.kt
@@ -1,0 +1,90 @@
+package com.voyagerfiles.viewmodel
+
+import android.app.Application
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.core.app.ApplicationProvider
+import com.voyagerfiles.data.local.PreferencesManager
+import com.voyagerfiles.data.model.FileSource
+import com.voyagerfiles.data.model.SessionAutoCloseTimeout
+import java.io.File
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class SessionAutoCloseTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var root: File
+    private lateinit var preferences: PreferencesManager
+
+    @Before
+    fun setUp() {
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        preferences = PreferencesManager(application)
+        runBlocking {
+            preferences.setAutoCloseSessions(false)
+            preferences.setSessionAutoCloseTimeout(SessionAutoCloseTimeout.FIVE_MINUTES)
+        }
+        root = File(application.cacheDir, "session-auto-close-test").apply {
+            deleteRecursively()
+            mkdirs()
+            resolve("notes.txt").writeText("notes")
+        }
+    }
+
+    @After
+    fun tearDown() {
+        root.deleteRecursively()
+        runBlocking {
+            preferences.setAutoCloseSessions(false)
+            preferences.setSessionAutoCloseTimeout(SessionAutoCloseTimeout.FIFTEEN_MINUTES)
+        }
+    }
+
+    @Test
+    fun expiredBackgroundIntervalClosesSessionsAndProviderBackedState() {
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        val viewModel = FileBrowserViewModel(application)
+        composeTestRule.setContent {}
+        composeTestRule.runOnIdle {
+            viewModel.openLocalRoot(root.absolutePath)
+        }
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            viewModel.sessions.value.size == 1 &&
+                viewModel.browseState.value.currentPath == root.absolutePath &&
+                !viewModel.browseState.value.isLoading
+        }
+        composeTestRule.runOnIdle {
+            viewModel.copyToClipboard(listOf(root.resolve("notes.txt").absolutePath))
+            viewModel.setAutoCloseSessions(true)
+        }
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            viewModel.autoCloseSessions.value
+        }
+        val previousGeneration = viewModel.sessionClosureGeneration.value
+
+        composeTestRule.runOnIdle {
+            viewModel.onAppBackgrounded(nowMillis = 1_000L)
+            viewModel.onAppForegrounded(
+                nowMillis = 1_000L + SessionAutoCloseTimeout.FIVE_MINUTES.durationMillis,
+            )
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            viewModel.sessions.value.isEmpty() &&
+                viewModel.sessionClosureGeneration.value == previousGeneration + 1L
+        }
+        assertNull(viewModel.activeSession.value)
+        assertTrue(viewModel.clipboardPaths.value.isEmpty())
+        assertEquals(ClipboardOperation.NONE, viewModel.clipboardOperation.value)
+        assertEquals(FileSource.LOCAL, viewModel.browseState.value.source)
+        assertTrue(viewModel.browseState.value.files.isEmpty())
+    }
+}

--- a/app/src/main/java/com/voyagerfiles/app/MainActivity.kt
+++ b/app/src/main/java/com/voyagerfiles/app/MainActivity.kt
@@ -7,6 +7,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.Environment
+import android.os.SystemClock
 import android.provider.Settings
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -77,6 +78,12 @@ class MainActivity : ComponentActivity() {
     override fun onResume() {
         super.onResume()
         hasStoragePermission.value = checkStoragePermission()
+        viewModel.onAppForegrounded(SystemClock.elapsedRealtime())
+    }
+
+    override fun onStop() {
+        viewModel.onAppBackgrounded(SystemClock.elapsedRealtime())
+        super.onStop()
     }
 
     private fun checkStoragePermission(): Boolean {

--- a/app/src/main/java/com/voyagerfiles/data/local/PreferencesManager.kt
+++ b/app/src/main/java/com/voyagerfiles/data/local/PreferencesManager.kt
@@ -10,6 +10,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.voyagerfiles.data.model.SortBy
 import com.voyagerfiles.data.model.SortOrder
+import com.voyagerfiles.data.model.SessionAutoCloseTimeout
 import com.voyagerfiles.data.model.ViewMode
 import com.voyagerfiles.ui.theme.AppTheme
 import kotlinx.coroutines.flow.Flow
@@ -28,6 +29,8 @@ class PreferencesManager(private val context: Context) {
         val SORT_ORDER = stringPreferencesKey("sort_order")
         val VIEW_MODE = stringPreferencesKey("view_mode")
         val DEFAULT_PATH = stringPreferencesKey("default_path")
+        val AUTO_CLOSE_SESSIONS = booleanPreferencesKey("auto_close_sessions")
+        val SESSION_AUTO_CLOSE_TIMEOUT = stringPreferencesKey("session_auto_close_timeout")
         val CUSTOM_PRIMARY = longPreferencesKey("custom_primary")
         val CUSTOM_BACKGROUND = longPreferencesKey("custom_background")
         val CUSTOM_SURFACE = longPreferencesKey("custom_surface")
@@ -66,6 +69,14 @@ class PreferencesManager(private val context: Context) {
 
     val defaultPath: Flow<String> = context.dataStore.data.map { prefs ->
         prefs[Keys.DEFAULT_PATH] ?: "/storage/emulated/0"
+    }
+
+    val autoCloseSessions: Flow<Boolean> = context.dataStore.data.map { prefs ->
+        prefs[Keys.AUTO_CLOSE_SESSIONS] ?: false
+    }
+
+    val sessionAutoCloseTimeout: Flow<SessionAutoCloseTimeout> = context.dataStore.data.map { prefs ->
+        SessionAutoCloseTimeout.fromName(prefs[Keys.SESSION_AUTO_CLOSE_TIMEOUT])
     }
 
     val customPrimary: Flow<Long> = context.dataStore.data.map { prefs ->
@@ -110,6 +121,14 @@ class PreferencesManager(private val context: Context) {
 
     suspend fun setDefaultPath(path: String) {
         context.dataStore.edit { it[Keys.DEFAULT_PATH] = path }
+    }
+
+    suspend fun setAutoCloseSessions(enabled: Boolean) {
+        context.dataStore.edit { it[Keys.AUTO_CLOSE_SESSIONS] = enabled }
+    }
+
+    suspend fun setSessionAutoCloseTimeout(timeout: SessionAutoCloseTimeout) {
+        context.dataStore.edit { it[Keys.SESSION_AUTO_CLOSE_TIMEOUT] = timeout.name }
     }
 
     suspend fun setCustomColors(primary: Long, background: Long, surface: Long) {

--- a/app/src/main/java/com/voyagerfiles/data/model/SessionAutoCloseTimeout.kt
+++ b/app/src/main/java/com/voyagerfiles/data/model/SessionAutoCloseTimeout.kt
@@ -1,0 +1,20 @@
+package com.voyagerfiles.data.model
+
+enum class SessionAutoCloseTimeout(
+    val minutes: Long,
+    val label: String,
+) {
+    FIVE_MINUTES(5L, "5 minutes"),
+    FIFTEEN_MINUTES(15L, "15 minutes"),
+    THIRTY_MINUTES(30L, "30 minutes"),
+    ONE_HOUR(60L, "1 hour"),
+    ;
+
+    val durationMillis: Long
+        get() = minutes * 60_000L
+
+    companion object {
+        fun fromName(name: String?): SessionAutoCloseTimeout =
+            entries.firstOrNull { it.name == name } ?: FIFTEEN_MINUTES
+    }
+}

--- a/app/src/main/java/com/voyagerfiles/ui/screens/Navigation.kt
+++ b/app/src/main/java/com/voyagerfiles/ui/screens/Navigation.kt
@@ -41,6 +41,7 @@ fun AppNavigation(
     LaunchedEffect(sessionClosureGeneration) {
         if (
             sessionClosureGeneration > 0L &&
+            viewModel.sessions.value.isEmpty() &&
             navController.currentDestination?.route == Screen.Browser.route
         ) {
             navController.navigateHome()

--- a/app/src/main/java/com/voyagerfiles/ui/screens/Navigation.kt
+++ b/app/src/main/java/com/voyagerfiles/ui/screens/Navigation.kt
@@ -5,6 +5,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavType
 import androidx.navigation.NavHostController
@@ -33,6 +36,16 @@ fun AppNavigation(
     onRequestAllFilesAccess: () -> Unit,
 ) {
     val navController = rememberNavController()
+    val sessionClosureGeneration by viewModel.sessionClosureGeneration.collectAsState()
+
+    LaunchedEffect(sessionClosureGeneration) {
+        if (
+            sessionClosureGeneration > 0L &&
+            navController.currentDestination?.route == Screen.Browser.route
+        ) {
+            navController.navigateHome()
+        }
+    }
 
     NavHost(
         navController = navController,

--- a/app/src/main/java/com/voyagerfiles/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/voyagerfiles/ui/screens/SettingsScreen.kt
@@ -22,6 +22,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -31,20 +33,25 @@ import androidx.compose.material3.ScrollableTabRow
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.voyagerfiles.BuildConfig
+import com.voyagerfiles.data.model.SessionAutoCloseTimeout
 import com.voyagerfiles.ui.theme.AppTheme
 import com.voyagerfiles.ui.theme.BlackColors
 import com.voyagerfiles.ui.theme.DarkColors
@@ -78,7 +85,10 @@ fun SettingsScreen(
     val currentTheme by viewModel.theme.collectAsState()
     val browseState by viewModel.browseState.collectAsState()
     val useTrash by viewModel.useTrash.collectAsState()
+    val autoCloseSessions by viewModel.autoCloseSessions.collectAsState()
+    val sessionAutoCloseTimeout by viewModel.sessionAutoCloseTimeout.collectAsState()
     var selectedThemeCategoryIndex by rememberSaveable { mutableIntStateOf(0) }
+    var timeoutMenuExpanded by rememberSaveable { mutableStateOf(false) }
     val selectedThemeCategory = themeCategories[selectedThemeCategoryIndex]
 
     Scaffold(
@@ -161,6 +171,77 @@ fun SettingsScreen(
             Spacer(modifier = Modifier.height(12.dp))
             Button(onClick = onRequestAllFilesAccess) {
                 Text(if (hasAllFilesAccess) "Manage access" else "Grant full access")
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Text(
+                "Sessions",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Close inactive sessions", style = MaterialTheme.typography.bodyLarge)
+                    Text(
+                        "Close all sessions after Voyager stays in the background",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Spacer(modifier = Modifier.width(12.dp))
+                Switch(
+                    checked = autoCloseSessions,
+                    onCheckedChange = viewModel::setAutoCloseSessions,
+                    modifier = Modifier.semantics {
+                        contentDescription = "Auto-close sessions"
+                    },
+                )
+            }
+
+            if (autoCloseSessions) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 4.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text("Close after", style = MaterialTheme.typography.bodyLarge)
+                    Box {
+                        TextButton(
+                            onClick = { timeoutMenuExpanded = true },
+                            modifier = Modifier.semantics {
+                                contentDescription =
+                                    "Session timeout, current ${sessionAutoCloseTimeout.label}"
+                            },
+                        ) {
+                            Text(sessionAutoCloseTimeout.label)
+                        }
+                        DropdownMenu(
+                            expanded = timeoutMenuExpanded,
+                            onDismissRequest = { timeoutMenuExpanded = false },
+                        ) {
+                            SessionAutoCloseTimeout.entries.forEach { timeout ->
+                                DropdownMenuItem(
+                                    text = { Text(timeout.label) },
+                                    onClick = {
+                                        timeoutMenuExpanded = false
+                                        viewModel.setSessionAutoCloseTimeout(timeout)
+                                    },
+                                )
+                            }
+                        }
+                    }
+                }
             }
 
             Spacer(modifier = Modifier.height(24.dp))

--- a/app/src/main/java/com/voyagerfiles/viewmodel/FileBrowserViewModel.kt
+++ b/app/src/main/java/com/voyagerfiles/viewmodel/FileBrowserViewModel.kt
@@ -14,6 +14,7 @@ import com.voyagerfiles.data.model.FileItem
 import com.voyagerfiles.data.model.FileSource
 import com.voyagerfiles.data.model.FileTypeFilter
 import com.voyagerfiles.data.model.RemoteConnection
+import com.voyagerfiles.data.model.SessionAutoCloseTimeout
 import com.voyagerfiles.data.model.SortBy
 import com.voyagerfiles.data.model.SortOrder
 import com.voyagerfiles.data.model.TrashEntry
@@ -58,6 +59,7 @@ class FileBrowserViewModel(application: Application) : AndroidViewModel(applicat
     private var browserSessionRootPath: String? = null
     private val sessionProviders = mutableMapOf<String, FileProvider>()
     private val loadGuard = DirectoryLoadGuard()
+    private val sessionAutoCloseTracker = SessionAutoCloseTracker()
 
     private val _browseState = MutableStateFlow(BrowseState())
     val browseState: StateFlow<BrowseState> = _browseState.asStateFlow()
@@ -81,11 +83,20 @@ class FileBrowserViewModel(application: Application) : AndroidViewModel(applicat
     private val _operationState = MutableStateFlow<OperationState>(OperationState.Idle)
     val operationState: StateFlow<OperationState> = _operationState.asStateFlow()
 
+    private val _sessionClosureGeneration = MutableStateFlow(0L)
+    val sessionClosureGeneration: StateFlow<Long> = _sessionClosureGeneration.asStateFlow()
+
     private val _trashState = MutableStateFlow(TrashState())
     val trashState: StateFlow<TrashState> = _trashState.asStateFlow()
 
     val theme = prefs.theme.stateIn(viewModelScope, SharingStarted.Eagerly, AppTheme.SYSTEM)
     val useTrash = prefs.useTrash.stateIn(viewModelScope, SharingStarted.Eagerly, true)
+    val autoCloseSessions = prefs.autoCloseSessions.stateIn(viewModelScope, SharingStarted.Eagerly, false)
+    val sessionAutoCloseTimeout = prefs.sessionAutoCloseTimeout.stateIn(
+        viewModelScope,
+        SharingStarted.Eagerly,
+        SessionAutoCloseTimeout.FIFTEEN_MINUTES,
+    )
     val limitedAccessAccepted = prefs.limitedAccessAccepted.stateIn(viewModelScope, SharingStarted.Eagerly, false)
     val connections = connectionRepository.connections.stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
     val bookmarks = bookmarkDao.getAllBookmarks().stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
@@ -480,6 +491,20 @@ class FileBrowserViewModel(application: Application) : AndroidViewModel(applicat
         clipboardProvider = null
     }
 
+    fun onAppBackgrounded(nowMillis: Long) {
+        sessionAutoCloseTracker.onBackgrounded(nowMillis)
+    }
+
+    fun onAppForegrounded(nowMillis: Long) {
+        val shouldClose = sessionAutoCloseTracker.onForegrounded(
+            nowMillis = nowMillis,
+            enabled = autoCloseSessions.value,
+            timeoutMillis = sessionAutoCloseTimeout.value.durationMillis,
+            operationRunning = _operationState.value is OperationState.Running,
+        )
+        if (shouldClose) closeAllSessionsAfterInactivity()
+    }
+
     fun paste() {
         val paths = _clipboardPaths.value.toList()
         val operation = _clipboardOperation.value
@@ -756,6 +781,12 @@ class FileBrowserViewModel(application: Application) : AndroidViewModel(applicat
                 showSnackbar(OperationMessages.failure(label, error))
             } finally {
                 _operationState.value = OperationState.Idle
+                if (
+                    autoCloseSessions.value &&
+                    sessionAutoCloseTracker.consumePendingAfterOperation()
+                ) {
+                    closeAllSessionsAfterInactivity()
+                }
             }
         }
     }
@@ -836,6 +867,15 @@ class FileBrowserViewModel(application: Application) : AndroidViewModel(applicat
         viewModelScope.launch { prefs.setUseTrash(useTrash) }
     }
 
+    fun setAutoCloseSessions(enabled: Boolean) {
+        if (!enabled) sessionAutoCloseTracker.cancelPending()
+        viewModelScope.launch { prefs.setAutoCloseSessions(enabled) }
+    }
+
+    fun setSessionAutoCloseTimeout(timeout: SessionAutoCloseTimeout) {
+        viewModelScope.launch { prefs.setSessionAutoCloseTimeout(timeout) }
+    }
+
     fun setLimitedAccessAccepted(accepted: Boolean) {
         viewModelScope.launch { prefs.setLimitedAccessAccepted(accepted) }
     }
@@ -912,6 +952,36 @@ class FileBrowserViewModel(application: Application) : AndroidViewModel(applicat
                 searchQuery = "",
                 fileTypeFilter = FileTypeFilter.ALL,
             )
+        }
+    }
+
+    private fun closeAllSessionsAfterInactivity() {
+        val sessionCount = _sessions.value.size
+        if (sessionCount == 0) return
+        val providers = sessionProviders.values.toSet()
+        sessionProviders.clear()
+        loadGuard.nextRequest(null)
+        fileProvider = FileProviderFactory.createLocal()
+        browserSessionRootPath = null
+        _sessions.value = emptyList()
+        _activeSession.value = null
+        clearClipboard()
+        _browseState.update {
+            it.copy(
+                currentPath = "/",
+                files = emptyList(),
+                isLoading = false,
+                error = null,
+                selectedFiles = emptySet(),
+                source = FileSource.LOCAL,
+                searchQuery = "",
+                fileTypeFilter = FileTypeFilter.ALL,
+            )
+        }
+        _sessionClosureGeneration.value += 1L
+        showSnackbar("Closed $sessionCount inactive session${if (sessionCount == 1) "" else "s"}")
+        viewModelScope.launch {
+            providers.forEach { provider -> runCatching { provider.disconnect() } }
         }
     }
 

--- a/app/src/main/java/com/voyagerfiles/viewmodel/FileBrowserViewModel.kt
+++ b/app/src/main/java/com/voyagerfiles/viewmodel/FileBrowserViewModel.kt
@@ -60,6 +60,8 @@ class FileBrowserViewModel(application: Application) : AndroidViewModel(applicat
     private val sessionProviders = mutableMapOf<String, FileProvider>()
     private val loadGuard = DirectoryLoadGuard()
     private val sessionAutoCloseTracker = SessionAutoCloseTracker()
+    private var backgroundedSessionIds = emptySet<String>()
+    private var deferredAutoCloseSessionIds = emptySet<String>()
 
     private val _browseState = MutableStateFlow(BrowseState())
     val browseState: StateFlow<BrowseState> = _browseState.asStateFlow()
@@ -493,16 +495,25 @@ class FileBrowserViewModel(application: Application) : AndroidViewModel(applicat
 
     fun onAppBackgrounded(nowMillis: Long) {
         sessionAutoCloseTracker.onBackgrounded(nowMillis)
+        backgroundedSessionIds = _sessions.value.mapTo(mutableSetOf()) { it.id }
     }
 
     fun onAppForegrounded(nowMillis: Long) {
-        val shouldClose = sessionAutoCloseTracker.onForegrounded(
+        val sessionIds = backgroundedSessionIds
+        backgroundedSessionIds = emptySet()
+        val decision = sessionAutoCloseTracker.onForegrounded(
             nowMillis = nowMillis,
             enabled = autoCloseSessions.value,
             timeoutMillis = sessionAutoCloseTimeout.value.durationMillis,
             operationRunning = _operationState.value is OperationState.Running,
         )
-        if (shouldClose) closeAllSessionsAfterInactivity()
+        when (decision) {
+            SessionAutoCloseDecision.KEEP_OPEN -> Unit
+            SessionAutoCloseDecision.CLOSE_NOW -> closeSessionsAfterInactivity(sessionIds)
+            SessionAutoCloseDecision.DEFER_UNTIL_OPERATION_FINISHES -> {
+                deferredAutoCloseSessionIds = deferredAutoCloseSessionIds + sessionIds
+            }
+        }
     }
 
     fun paste() {
@@ -781,11 +792,10 @@ class FileBrowserViewModel(application: Application) : AndroidViewModel(applicat
                 showSnackbar(OperationMessages.failure(label, error))
             } finally {
                 _operationState.value = OperationState.Idle
-                if (
-                    autoCloseSessions.value &&
-                    sessionAutoCloseTracker.consumePendingAfterOperation()
-                ) {
-                    closeAllSessionsAfterInactivity()
+                if (autoCloseSessions.value && deferredAutoCloseSessionIds.isNotEmpty()) {
+                    val sessionIds = deferredAutoCloseSessionIds
+                    deferredAutoCloseSessionIds = emptySet()
+                    closeSessionsAfterInactivity(sessionIds)
                 }
             }
         }
@@ -868,7 +878,7 @@ class FileBrowserViewModel(application: Application) : AndroidViewModel(applicat
     }
 
     fun setAutoCloseSessions(enabled: Boolean) {
-        if (!enabled) sessionAutoCloseTracker.cancelPending()
+        if (!enabled) deferredAutoCloseSessionIds = emptySet()
         viewModelScope.launch { prefs.setAutoCloseSessions(enabled) }
     }
 
@@ -955,33 +965,62 @@ class FileBrowserViewModel(application: Application) : AndroidViewModel(applicat
         }
     }
 
-    private fun closeAllSessionsAfterInactivity() {
-        val sessionCount = _sessions.value.size
-        if (sessionCount == 0) return
-        val providers = sessionProviders.values.toSet()
-        sessionProviders.clear()
-        loadGuard.nextRequest(null)
-        fileProvider = FileProviderFactory.createLocal()
-        browserSessionRootPath = null
-        _sessions.value = emptyList()
-        _activeSession.value = null
+    private fun closeSessionsAfterInactivity(sessionIds: Set<String>) {
+        val closedSessions = _sessions.value.filter { it.id in sessionIds }
+        if (closedSessions.isEmpty()) return
+        val closedProviders = closedSessions.mapNotNull { session ->
+            sessionProviders.remove(session.id)
+        }.toSet()
+        val remainingSessions = _sessions.value.filterNot { it.id in sessionIds }
+        val activeSessionWasClosed = _activeSession.value?.id?.let { it in sessionIds } == true
+        _sessions.value = remainingSessions
         clearClipboard()
-        _browseState.update {
-            it.copy(
-                currentPath = "/",
-                files = emptyList(),
-                isLoading = false,
-                error = null,
-                selectedFiles = emptySet(),
-                source = FileSource.LOCAL,
-                searchQuery = "",
-                fileTypeFilter = FileTypeFilter.ALL,
-            )
+        _snackbarMessage.value = null
+
+        if (activeSessionWasClosed) {
+            val nextSession = remainingSessions.lastOrNull()
+            if (nextSession == null) {
+                loadGuard.nextRequest(null)
+                fileProvider = FileProviderFactory.createLocal()
+                browserSessionRootPath = null
+                _activeSession.value = null
+                _browseState.update {
+                    it.copy(
+                        currentPath = "/",
+                        files = emptyList(),
+                        isLoading = false,
+                        error = null,
+                        selectedFiles = emptySet(),
+                        source = FileSource.LOCAL,
+                        searchQuery = "",
+                        fileTypeFilter = FileTypeFilter.ALL,
+                    )
+                }
+            } else {
+                val nextProvider = checkNotNull(sessionProviders[nextSession.id])
+                fileProvider = nextProvider
+                browserSessionRootPath = nextSession.rootPath
+                _activeSession.value = nextSession
+                _browseState.update {
+                    it.copy(
+                        currentPath = nextSession.currentPath,
+                        source = nextSession.source,
+                        selectedFiles = emptySet(),
+                        error = null,
+                        searchQuery = "",
+                        fileTypeFilter = FileTypeFilter.ALL,
+                    )
+                }
+                viewModelScope.launch {
+                    loadFiles(nextSession.currentPath, nextSession.id, nextProvider)
+                }
+            }
+        } else {
+            refreshActiveSessionSnapshot()
         }
         _sessionClosureGeneration.value += 1L
-        showSnackbar("Closed $sessionCount inactive session${if (sessionCount == 1) "" else "s"}")
         viewModelScope.launch {
-            providers.forEach { provider -> runCatching { provider.disconnect() } }
+            closedProviders.forEach { provider -> runCatching { provider.disconnect() } }
         }
     }
 

--- a/app/src/main/java/com/voyagerfiles/viewmodel/SessionAutoCloseTracker.kt
+++ b/app/src/main/java/com/voyagerfiles/viewmodel/SessionAutoCloseTracker.kt
@@ -1,0 +1,42 @@
+package com.voyagerfiles.viewmodel
+
+class SessionAutoCloseTracker {
+    private var backgroundedAtMillis: Long? = null
+    private var pendingAfterOperation = false
+
+    fun onBackgrounded(nowMillis: Long) {
+        backgroundedAtMillis = nowMillis
+    }
+
+    fun onForegrounded(
+        nowMillis: Long,
+        enabled: Boolean,
+        timeoutMillis: Long,
+        operationRunning: Boolean,
+    ): Boolean {
+        val backgroundedAt = backgroundedAtMillis ?: return false
+        backgroundedAtMillis = null
+        if (!enabled) {
+            pendingAfterOperation = false
+            return false
+        }
+
+        val elapsedMillis = nowMillis - backgroundedAt
+        if (elapsedMillis < timeoutMillis || elapsedMillis < 0L) return false
+        if (operationRunning) {
+            pendingAfterOperation = true
+            return false
+        }
+        return true
+    }
+
+    fun consumePendingAfterOperation(): Boolean {
+        val pending = pendingAfterOperation
+        pendingAfterOperation = false
+        return pending
+    }
+
+    fun cancelPending() {
+        pendingAfterOperation = false
+    }
+}

--- a/app/src/main/java/com/voyagerfiles/viewmodel/SessionAutoCloseTracker.kt
+++ b/app/src/main/java/com/voyagerfiles/viewmodel/SessionAutoCloseTracker.kt
@@ -2,7 +2,6 @@ package com.voyagerfiles.viewmodel
 
 class SessionAutoCloseTracker {
     private var backgroundedAtMillis: Long? = null
-    private var pendingAfterOperation = false
 
     fun onBackgrounded(nowMillis: Long) {
         backgroundedAtMillis = nowMillis
@@ -13,30 +12,25 @@ class SessionAutoCloseTracker {
         enabled: Boolean,
         timeoutMillis: Long,
         operationRunning: Boolean,
-    ): Boolean {
-        val backgroundedAt = backgroundedAtMillis ?: return false
+    ): SessionAutoCloseDecision {
+        val backgroundedAt = backgroundedAtMillis ?: return SessionAutoCloseDecision.KEEP_OPEN
         backgroundedAtMillis = null
-        if (!enabled) {
-            pendingAfterOperation = false
-            return false
-        }
+        if (!enabled) return SessionAutoCloseDecision.KEEP_OPEN
 
         val elapsedMillis = nowMillis - backgroundedAt
-        if (elapsedMillis < timeoutMillis || elapsedMillis < 0L) return false
-        if (operationRunning) {
-            pendingAfterOperation = true
-            return false
+        if (elapsedMillis < timeoutMillis || elapsedMillis < 0L) {
+            return SessionAutoCloseDecision.KEEP_OPEN
         }
-        return true
+        return if (operationRunning) {
+            SessionAutoCloseDecision.DEFER_UNTIL_OPERATION_FINISHES
+        } else {
+            SessionAutoCloseDecision.CLOSE_NOW
+        }
     }
+}
 
-    fun consumePendingAfterOperation(): Boolean {
-        val pending = pendingAfterOperation
-        pendingAfterOperation = false
-        return pending
-    }
-
-    fun cancelPending() {
-        pendingAfterOperation = false
-    }
+enum class SessionAutoCloseDecision {
+    KEEP_OPEN,
+    CLOSE_NOW,
+    DEFER_UNTIL_OPERATION_FINISHES,
 }

--- a/app/src/test/java/com/voyagerfiles/data/model/SessionAutoCloseTimeoutTest.kt
+++ b/app/src/test/java/com/voyagerfiles/data/model/SessionAutoCloseTimeoutTest.kt
@@ -1,0 +1,35 @@
+package com.voyagerfiles.data.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SessionAutoCloseTimeoutTest {
+
+    @Test
+    fun choicesExposeExpectedLabelsAndDurations() {
+        assertEquals(
+            listOf("5 minutes", "15 minutes", "30 minutes", "1 hour"),
+            SessionAutoCloseTimeout.entries.map { it.label },
+        )
+        assertEquals(
+            listOf(5L, 15L, 30L, 60L).map { it * 60_000L },
+            SessionAutoCloseTimeout.entries.map { it.durationMillis },
+        )
+    }
+
+    @Test
+    fun persistedNameFallsBackToFifteenMinutes() {
+        assertEquals(
+            SessionAutoCloseTimeout.FIVE_MINUTES,
+            SessionAutoCloseTimeout.fromName(SessionAutoCloseTimeout.FIVE_MINUTES.name),
+        )
+        assertEquals(
+            SessionAutoCloseTimeout.FIFTEEN_MINUTES,
+            SessionAutoCloseTimeout.fromName(null),
+        )
+        assertEquals(
+            SessionAutoCloseTimeout.FIFTEEN_MINUTES,
+            SessionAutoCloseTimeout.fromName("REMOVED_CHOICE"),
+        )
+    }
+}

--- a/app/src/test/java/com/voyagerfiles/viewmodel/SessionAutoCloseTrackerTest.kt
+++ b/app/src/test/java/com/voyagerfiles/viewmodel/SessionAutoCloseTrackerTest.kt
@@ -1,0 +1,113 @@
+package com.voyagerfiles.viewmodel
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SessionAutoCloseTrackerTest {
+
+    private val tracker = SessionAutoCloseTracker()
+
+    @Test
+    fun foregroundBelowThresholdKeepsSessionsOpen() {
+        tracker.onBackgrounded(nowMillis = 1_000L)
+
+        assertFalse(
+            tracker.onForegrounded(
+                nowMillis = 1_000L + TIMEOUT_MILLIS - 1L,
+                enabled = true,
+                timeoutMillis = TIMEOUT_MILLIS,
+                operationRunning = false,
+            )
+        )
+    }
+
+    @Test
+    fun foregroundAtThresholdClosesSessions() {
+        tracker.onBackgrounded(nowMillis = 1_000L)
+
+        assertTrue(
+            tracker.onForegrounded(
+                nowMillis = 1_000L + TIMEOUT_MILLIS,
+                enabled = true,
+                timeoutMillis = TIMEOUT_MILLIS,
+                operationRunning = false,
+            )
+        )
+    }
+
+    @Test
+    fun disabledSettingKeepsSessionsOpen() {
+        tracker.onBackgrounded(nowMillis = 1_000L)
+
+        assertFalse(
+            tracker.onForegrounded(
+                nowMillis = 1_000L + TIMEOUT_MILLIS,
+                enabled = false,
+                timeoutMillis = TIMEOUT_MILLIS,
+                operationRunning = false,
+            )
+        )
+    }
+
+    @Test
+    fun clockRollbackKeepsSessionsOpen() {
+        tracker.onBackgrounded(nowMillis = 2_000L)
+
+        assertFalse(
+            tracker.onForegrounded(
+                nowMillis = 1_000L,
+                enabled = true,
+                timeoutMillis = TIMEOUT_MILLIS,
+                operationRunning = false,
+            )
+        )
+    }
+
+    @Test
+    fun expiredIntervalDefersWhileOperationRuns() {
+        tracker.onBackgrounded(nowMillis = 1_000L)
+
+        assertFalse(
+            tracker.onForegrounded(
+                nowMillis = 1_000L + TIMEOUT_MILLIS,
+                enabled = true,
+                timeoutMillis = TIMEOUT_MILLIS,
+                operationRunning = true,
+            )
+        )
+        assertTrue(tracker.consumePendingAfterOperation())
+        assertFalse(tracker.consumePendingAfterOperation())
+    }
+
+    @Test
+    fun canceledPendingClosureIsNotConsumed() {
+        tracker.onBackgrounded(nowMillis = 1_000L)
+        tracker.onForegrounded(
+            nowMillis = 1_000L + TIMEOUT_MILLIS,
+            enabled = true,
+            timeoutMillis = TIMEOUT_MILLIS,
+            operationRunning = true,
+        )
+
+        tracker.cancelPending()
+
+        assertFalse(tracker.consumePendingAfterOperation())
+    }
+
+    @Test
+    fun foregroundWithoutBackgroundEventKeepsSessionsOpen() {
+        assertFalse(
+            tracker.onForegrounded(
+                nowMillis = TIMEOUT_MILLIS,
+                enabled = true,
+                timeoutMillis = TIMEOUT_MILLIS,
+                operationRunning = false,
+            )
+        )
+    }
+
+    private companion object {
+        const val TIMEOUT_MILLIS = 5L * 60_000L
+    }
+}

--- a/app/src/test/java/com/voyagerfiles/viewmodel/SessionAutoCloseTrackerTest.kt
+++ b/app/src/test/java/com/voyagerfiles/viewmodel/SessionAutoCloseTrackerTest.kt
@@ -1,7 +1,6 @@
 package com.voyagerfiles.viewmodel
 
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class SessionAutoCloseTrackerTest {
@@ -12,7 +11,8 @@ class SessionAutoCloseTrackerTest {
     fun foregroundBelowThresholdKeepsSessionsOpen() {
         tracker.onBackgrounded(nowMillis = 1_000L)
 
-        assertFalse(
+        assertEquals(
+            SessionAutoCloseDecision.KEEP_OPEN,
             tracker.onForegrounded(
                 nowMillis = 1_000L + TIMEOUT_MILLIS - 1L,
                 enabled = true,
@@ -26,7 +26,8 @@ class SessionAutoCloseTrackerTest {
     fun foregroundAtThresholdClosesSessions() {
         tracker.onBackgrounded(nowMillis = 1_000L)
 
-        assertTrue(
+        assertEquals(
+            SessionAutoCloseDecision.CLOSE_NOW,
             tracker.onForegrounded(
                 nowMillis = 1_000L + TIMEOUT_MILLIS,
                 enabled = true,
@@ -40,7 +41,8 @@ class SessionAutoCloseTrackerTest {
     fun disabledSettingKeepsSessionsOpen() {
         tracker.onBackgrounded(nowMillis = 1_000L)
 
-        assertFalse(
+        assertEquals(
+            SessionAutoCloseDecision.KEEP_OPEN,
             tracker.onForegrounded(
                 nowMillis = 1_000L + TIMEOUT_MILLIS,
                 enabled = false,
@@ -54,7 +56,8 @@ class SessionAutoCloseTrackerTest {
     fun clockRollbackKeepsSessionsOpen() {
         tracker.onBackgrounded(nowMillis = 2_000L)
 
-        assertFalse(
+        assertEquals(
+            SessionAutoCloseDecision.KEEP_OPEN,
             tracker.onForegrounded(
                 nowMillis = 1_000L,
                 enabled = true,
@@ -68,7 +71,8 @@ class SessionAutoCloseTrackerTest {
     fun expiredIntervalDefersWhileOperationRuns() {
         tracker.onBackgrounded(nowMillis = 1_000L)
 
-        assertFalse(
+        assertEquals(
+            SessionAutoCloseDecision.DEFER_UNTIL_OPERATION_FINISHES,
             tracker.onForegrounded(
                 nowMillis = 1_000L + TIMEOUT_MILLIS,
                 enabled = true,
@@ -76,12 +80,10 @@ class SessionAutoCloseTrackerTest {
                 operationRunning = true,
             )
         )
-        assertTrue(tracker.consumePendingAfterOperation())
-        assertFalse(tracker.consumePendingAfterOperation())
     }
 
     @Test
-    fun canceledPendingClosureIsNotConsumed() {
+    fun deferredDecisionIsNotReusedOnAnotherForegroundEvent() {
         tracker.onBackgrounded(nowMillis = 1_000L)
         tracker.onForegrounded(
             nowMillis = 1_000L + TIMEOUT_MILLIS,
@@ -90,14 +92,21 @@ class SessionAutoCloseTrackerTest {
             operationRunning = true,
         )
 
-        tracker.cancelPending()
-
-        assertFalse(tracker.consumePendingAfterOperation())
+        assertEquals(
+            SessionAutoCloseDecision.KEEP_OPEN,
+            tracker.onForegrounded(
+                nowMillis = 1_000L + TIMEOUT_MILLIS,
+                enabled = true,
+                timeoutMillis = TIMEOUT_MILLIS,
+                operationRunning = false,
+            ),
+        )
     }
 
     @Test
     fun foregroundWithoutBackgroundEventKeepsSessionsOpen() {
-        assertFalse(
+        assertEquals(
+            SessionAutoCloseDecision.KEEP_OPEN,
             tracker.onForegrounded(
                 nowMillis = TIMEOUT_MILLIS,
                 enabled = true,

--- a/docs/superpowers/plans/2026-07-19-session-auto-close.md
+++ b/docs/superpowers/plans/2026-07-19-session-auto-close.md
@@ -1,0 +1,68 @@
+# Session Auto-Close Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a safe, optional inactivity timeout that closes all browser sessions after Voyager has remained fully backgrounded.
+
+**Architecture:** Persist an enable flag and timeout enum, evaluate background intervals with a pure state machine using elapsed realtime, let FileBrowserViewModel own session cleanup and operation deferral, and let navigation react to a closure generation while Browser is visible.
+
+**Tech Stack:** Kotlin 2.1, Android DataStore Preferences, Android lifecycle callbacks, SystemClock, Jetpack Compose Material 3, Kotlin coroutines, JUnit 4, AndroidX Compose UI tests.
+
+## Global Constraints
+
+- Default to disabled and retain the selected interval when disabled.
+- Measure only time between Activity `onStop` and `onResume` using a monotonic clock.
+- Do not interrupt active operations.
+- Disconnect every provider and clear provider-backed clipboard references.
+- Preserve view, sort, hidden-file, and theme preferences.
+- Keep prose in Markdown as one paragraph per physical line and do not add AI-authorship markers.
+
+### Task 1: Model timeout preferences and state transitions
+
+**Files:**
+- Create: `app/src/main/java/com/voyagerfiles/data/model/SessionAutoCloseTimeout.kt`
+- Create: `app/src/main/java/com/voyagerfiles/viewmodel/SessionAutoCloseTracker.kt`
+- Modify: `app/src/main/java/com/voyagerfiles/data/local/PreferencesManager.kt`
+- Test: `app/src/test/java/com/voyagerfiles/data/model/SessionAutoCloseTimeoutTest.kt`
+- Test: `app/src/test/java/com/voyagerfiles/viewmodel/SessionAutoCloseTrackerTest.kt`
+
+- [ ] Write failing tests for enum fallback, durations, threshold boundaries, disabled behavior, deferred closure, pending consumption, cancellation, and clock rollback.
+- [ ] Run the focused unit tests and verify RED.
+- [ ] Implement the enum, pure tracker, DataStore flows, and setters.
+- [ ] Run the focused unit tests and verify GREEN.
+- [ ] Commit the model boundary.
+
+### Task 2: Close sessions safely through the view model
+
+**Files:**
+- Modify: `app/src/main/java/com/voyagerfiles/viewmodel/FileBrowserViewModel.kt`
+- Create: `app/src/androidTest/java/com/voyagerfiles/viewmodel/SessionAutoCloseTest.kt`
+
+- [ ] Write a failing Android test that enables auto-close, opens a session, populates clipboard state, simulates the threshold, and asserts complete cleanup plus a generation increment.
+- [ ] Expose preference StateFlows and setters, add lifecycle entry points, defer closure while `OperationState.Running`, and implement one-pass provider cleanup.
+- [ ] Run the focused Android test and verify GREEN.
+- [ ] Commit view-model cleanup.
+
+### Task 3: Add lifecycle, Settings, and navigation integration
+
+**Files:**
+- Modify: `app/src/main/java/com/voyagerfiles/app/MainActivity.kt`
+- Modify: `app/src/main/java/com/voyagerfiles/ui/screens/SettingsScreen.kt`
+- Modify: `app/src/main/java/com/voyagerfiles/ui/screens/Navigation.kt`
+- Create: `app/src/androidTest/java/com/voyagerfiles/ui/screens/SessionAutoCloseSettingsTest.kt`
+- Create: `app/src/androidTest/java/com/voyagerfiles/ui/screens/SessionAutoCloseNavigationTest.kt`
+
+- [ ] Write failing Compose tests for the toggle, timeout selection, persisted flows, and Browser-to-Home navigation after closure.
+- [ ] Report `elapsedRealtime()` from MainActivity `onStop` and `onResume`.
+- [ ] Add a Sessions settings section with an accessible toggle and interval dropdown.
+- [ ] Observe the closure generation and navigate Home only from Browser.
+- [ ] Run focused connected tests and verify GREEN.
+- [ ] Commit lifecycle and UI integration.
+
+### Task 4: Verify and publish
+
+- [ ] Run `git diff --check master...HEAD`.
+- [ ] Run `./gradlew testDebugUnitTest lintDebug assembleDebug assembleRelease --rerun-tasks --stacktrace`.
+- [ ] Run `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew connectedDebugAndroidTest --rerun-tasks --stacktrace`.
+- [ ] Exercise Settings and background timeout behavior on the connected device with a short injected threshold or deterministic instrumentation coverage, and inspect logs for uncaught failures.
+- [ ] Push the branch, open a draft pull request with `Fixes #20`, wait for CI, then mark ready and merge only after all gates pass.

--- a/docs/superpowers/plans/2026-07-19-session-auto-close.md
+++ b/docs/superpowers/plans/2026-07-19-session-auto-close.md
@@ -13,7 +13,7 @@
 - Default to disabled and retain the selected interval when disabled.
 - Measure only time between Activity `onStop` and `onResume` using a monotonic clock.
 - Do not interrupt active operations.
-- Disconnect every provider and clear provider-backed clipboard references.
+- Disconnect every provider that belonged to a session present at `onStop`, preserve sessions created by returning Activity Result callbacks, and clear provider-backed clipboard references.
 - Preserve view, sort, hidden-file, and theme preferences.
 - Keep prose in Markdown as one paragraph per physical line and do not add AI-authorship markers.
 
@@ -38,8 +38,8 @@
 - Modify: `app/src/main/java/com/voyagerfiles/viewmodel/FileBrowserViewModel.kt`
 - Create: `app/src/androidTest/java/com/voyagerfiles/viewmodel/SessionAutoCloseTest.kt`
 
-- [ ] Write a failing Android test that enables auto-close, opens a session, populates clipboard state, simulates the threshold, and asserts complete cleanup plus a generation increment.
-- [ ] Expose preference StateFlows and setters, add lifecycle entry points, defer closure while `OperationState.Running`, and implement one-pass provider cleanup.
+- [ ] Write failing Android tests that enable auto-close, open a session, populate clipboard state, simulate the threshold, and assert complete cleanup plus a generation increment, then verify closure waits for an active operation.
+- [ ] Expose preference StateFlows and setters, snapshot session IDs at `onStop`, add lifecycle entry points, defer closure while `OperationState.Running`, and implement one-pass provider cleanup.
 - [ ] Run the focused Android test and verify GREEN.
 - [ ] Commit view-model cleanup.
 
@@ -52,7 +52,7 @@
 - Create: `app/src/androidTest/java/com/voyagerfiles/ui/screens/SessionAutoCloseSettingsTest.kt`
 - Create: `app/src/androidTest/java/com/voyagerfiles/ui/screens/SessionAutoCloseNavigationTest.kt`
 
-- [ ] Write failing Compose tests for the toggle, timeout selection, persisted flows, and Browser-to-Home navigation after closure.
+- [ ] Write failing Compose tests for the toggle, timeout selection, persisted flows, Browser-to-Home navigation after closure, and preservation of a session created by a returning picker result.
 - [ ] Report `elapsedRealtime()` from MainActivity `onStop` and `onResume`.
 - [ ] Add a Sessions settings section with an accessible toggle and interval dropdown.
 - [ ] Observe the closure generation and navigate Home only from Browser.

--- a/docs/superpowers/specs/2026-07-19-session-auto-close-design.md
+++ b/docs/superpowers/specs/2026-07-19-session-auto-close-design.md
@@ -1,0 +1,56 @@
+# Session Auto-Close Design
+
+## Problem
+
+Voyager keeps browser sessions and their local, SAF, FTP, SFTP, SMB, or WebDAV providers alive for the lifetime of the running app process. Users who leave Voyager in the background may therefore retain network connections longer than intended. Issue #20 requests an optional inactivity timeout that closes sessions automatically.
+
+## Requirements
+
+- Keep automatic closure disabled by default.
+- Let users choose 5, 15, 30, or 60 minutes while retaining the last choice when the toggle is disabled.
+- Define inactivity as time during which Voyager is fully backgrounded and not visible.
+- Use a monotonic clock so wall-clock changes cannot trigger or postpone closure.
+- Close every browser session once the configured interval has elapsed.
+- Never interrupt an active file operation. If the interval expires during an operation, close sessions immediately after the operation finishes.
+- Return an open Browser destination to Home after automatic closure while leaving unrelated Settings, Connections, or Trash navigation intact.
+- Disconnect each provider, clear stale clipboard references, and reset browser state without changing display preferences.
+
+## Considered Approaches
+
+### User-input idle timer
+
+Resetting a timer for taps and key events would make visible sessions expire while users are reading or while long provider work is active. It would also require broad event plumbing across Compose. This does not match the safer interpretation raised in the issue discussion.
+
+### Scheduled background task
+
+WorkManager or an alarm could wake the app at the exact deadline, but sessions exist only inside the current process. If the process dies, providers are already gone. Waking a background process solely to close in-memory resources adds complexity without improving correctness.
+
+### Compare background and foreground timestamps
+
+MainActivity records `SystemClock.elapsedRealtime()` in `onStop` and asks the view model to evaluate the interval in `onResume`. Android calls `onStop` when the activity is no longer visible, and elapsed realtime is monotonic and includes deep sleep. This approach needs no background wakeup and is the selected design.
+
+## Design
+
+`SessionAutoCloseTimeout` is a persisted enum with labels and durations for 5, 15, 30, and 60 minutes. `PreferencesManager` stores an enable flag and the selected enum name. `FileBrowserViewModel` exposes both as eager StateFlows and supplies setters for Settings.
+
+`SessionAutoCloseTracker` is a pure Kotlin state machine. It records the most recent background timestamp, compares the elapsed duration on foreground, and returns whether sessions should close. If the timeout expired while an operation is running, the tracker records a pending closure. The operation launcher consumes that pending closure from its `finally` block after changing the operation state to Idle. Disabling the preference cancels pending closure.
+
+`MainActivity.onStop` reports the monotonic background timestamp. `onResume` reports the foreground timestamp after Activity Result callbacks have had an opportunity to start a picker-driven upload. The Activity remains responsible only for lifecycle observation; timeout policy and session mutation stay in the view model.
+
+Automatic closure snapshots and clears all session providers before disconnecting them, replaces the active provider with a fresh local provider, clears sessions, active session, clipboard, and transient browser contents, then increments a closure generation. `AppNavigation` observes that generation and navigates to Home only when Browser is the current route. The generation is an event counter rather than a one-shot boolean, so each closure is observable without resetting shared state.
+
+## Testing
+
+- Unit-test timeout parsing, labels, and duration values.
+- Unit-test below-threshold, exact-threshold, disabled, negative-clock, deferred-operation, consumed-pending, and canceled-pending tracker behavior.
+- Add an Android view-model test that persists the setting, opens a local session, simulates an expired background interval, and verifies that sessions and clipboard state are cleared and the closure generation increments.
+- Add a Settings Compose test that enables auto-close, changes the timeout, and verifies persistence through the view-model flows.
+- Add an AppNavigation Compose test that verifies an automatically closed Browser returns to Home.
+- Run the full unit, lint, debug assembly, release assembly, and connected-device test gates.
+
+## Non-goals
+
+- Sessions are not restored after process death.
+- The app does not wake itself at the timeout deadline while backgrounded; it closes retained sessions when it next becomes active.
+- Individual sessions do not have separate timeouts.
+- Visible user-input inactivity is not measured.

--- a/docs/superpowers/specs/2026-07-19-session-auto-close-design.md
+++ b/docs/superpowers/specs/2026-07-19-session-auto-close-design.md
@@ -10,7 +10,8 @@ Voyager keeps browser sessions and their local, SAF, FTP, SFTP, SMB, or WebDAV p
 - Let users choose 5, 15, 30, or 60 minutes while retaining the last choice when the toggle is disabled.
 - Define inactivity as time during which Voyager is fully backgrounded and not visible.
 - Use a monotonic clock so wall-clock changes cannot trigger or postpone closure.
-- Close every browser session once the configured interval has elapsed.
+- Close every browser session that was already open when Voyager entered the background once the configured interval has elapsed.
+- Preserve a session created by an Activity Result callback while Voyager is returning from the system picker.
 - Never interrupt an active file operation. If the interval expires during an operation, close sessions immediately after the operation finishes.
 - Return an open Browser destination to Home after automatic closure while leaving unrelated Settings, Connections, or Trash navigation intact.
 - Disconnect each provider, clear stale clipboard references, and reset browser state without changing display preferences.
@@ -33,11 +34,11 @@ MainActivity records `SystemClock.elapsedRealtime()` in `onStop` and asks the vi
 
 `SessionAutoCloseTimeout` is a persisted enum with labels and durations for 5, 15, 30, and 60 minutes. `PreferencesManager` stores an enable flag and the selected enum name. `FileBrowserViewModel` exposes both as eager StateFlows and supplies setters for Settings.
 
-`SessionAutoCloseTracker` is a pure Kotlin state machine. It records the most recent background timestamp, compares the elapsed duration on foreground, and returns whether sessions should close. If the timeout expired while an operation is running, the tracker records a pending closure. The operation launcher consumes that pending closure from its `finally` block after changing the operation state to Idle. Disabling the preference cancels pending closure.
+`SessionAutoCloseTracker` is a pure Kotlin state machine. It records the most recent background timestamp, compares the elapsed duration on foreground, and returns whether sessions should remain open, close now, or close after an operation. The view model snapshots the IDs of sessions present at `onStop`, so an SAF session created by the returning picker callback before `onResume` is not treated as stale. If the timeout expired while an operation is running, the operation launcher consumes the snapshotted IDs from its `finally` block after changing the operation state to Idle. Disabling the preference cancels deferred closure.
 
 `MainActivity.onStop` reports the monotonic background timestamp. `onResume` reports the foreground timestamp after Activity Result callbacks have had an opportunity to start a picker-driven upload. The Activity remains responsible only for lifecycle observation; timeout policy and session mutation stay in the view model.
 
-Automatic closure snapshots and clears all session providers before disconnecting them, replaces the active provider with a fresh local provider, clears sessions, active session, clipboard, and transient browser contents, then increments a closure generation. `AppNavigation` observes that generation and navigates to Home only when Browser is the current route. The generation is an event counter rather than a one-shot boolean, so each closure is observable without resetting shared state.
+Automatic closure removes and disconnects the snapshotted session providers, clears provider-backed clipboard and snackbar state, and preserves any session created while returning from a picker. If no sessions remain, it replaces the active provider with a fresh local provider and clears transient browser contents. It then increments a closure generation. `AppNavigation` observes that generation and navigates to Home only when Browser is the current route and no session remains. The generation is an event counter rather than a one-shot boolean, so each closure is observable without resetting shared state.
 
 ## Testing
 
@@ -46,6 +47,8 @@ Automatic closure snapshots and clears all session providers before disconnectin
 - Add an Android view-model test that persists the setting, opens a local session, simulates an expired background interval, and verifies that sessions and clipboard state are cleared and the closure generation increments.
 - Add a Settings Compose test that enables auto-close, changes the timeout, and verifies persistence through the view-model flows.
 - Add an AppNavigation Compose test that verifies an automatically closed Browser returns to Home.
+- Add an AppNavigation regression test that creates a session between the background and foreground callbacks, then verifies that only the pre-existing session closes and Browser remains open.
+- Verify that automatic closure clears stale snackbar state before a later Browser can consume it.
 - Run the full unit, lint, debug assembly, release assembly, and connected-device test gates.
 
 ## Non-goals


### PR DESCRIPTION
## Summary

- add an off-by-default setting to close sessions after 5, 15, 30, or 60 minutes in the background
- use elapsed realtime across Activity stop and resume, and defer closure until an active file operation finishes
- snapshot sessions at stop time so a session created by a returning system-picker result is preserved
- disconnect timed-out session providers, clear provider-backed clipboard state, and return an empty Browser to Home

## Verification

- `./gradlew --no-daemon --max-workers=2 -Dorg.gradle.jvmargs='-Xmx4096m -Dfile.encoding=UTF-8' testDebugUnitTest lintDebug assembleDebug assembleRelease --rerun-tasks --stacktrace`
- 119 unit tests discovered, 2 environment-dependent tests skipped, 0 failures
- `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew connectedDebugAndroidTest --rerun-tasks --stacktrace`
- 23 connected tests on Android 16, 0 failures
- manually inspected disabled and enabled Settings states on the connected Android 16 device

Fixes #20