### PR TITLE
Customize Home sections

### DIFF
--- a/app/src/androidTest/java/com/voyagerfiles/ui/screens/CustomHomeLayoutTest.kt
+++ b/app/src/androidTest/java/com/voyagerfiles/ui/screens/CustomHomeLayoutTest.kt
@@ -64,7 +64,7 @@ class CustomHomeLayoutTest {
             }
         }
         composeTestRule.waitUntil(timeoutMillis = 10_000) {
-            viewModel.homeLayout.value.visibleSections.first() == HomeSection.REMOTE_CONNECTIONS
+            viewModel.homeLayout.value?.visibleSections?.firstOrNull() == HomeSection.REMOTE_CONNECTIONS
         }
 
         composeTestRule.onNodeWithText("Quick Access").assertDoesNotExist()

--- a/app/src/androidTest/java/com/voyagerfiles/ui/screens/CustomHomeLayoutTest.kt
+++ b/app/src/androidTest/java/com/voyagerfiles/ui/screens/CustomHomeLayoutTest.kt
@@ -1,0 +1,78 @@
+package com.voyagerfiles.ui.screens
+
+import android.app.Application
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
+import com.voyagerfiles.data.local.PreferencesManager
+import com.voyagerfiles.data.model.HomeLayout
+import com.voyagerfiles.data.model.HomeSection
+import com.voyagerfiles.viewmodel.FileBrowserViewModel
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class CustomHomeLayoutTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var application: Application
+    private lateinit var preferences: PreferencesManager
+
+    @Before
+    fun setUp() {
+        application = ApplicationProvider.getApplicationContext()
+        preferences = PreferencesManager(application)
+        runBlocking {
+            preferences.setHomeLayout(
+                HomeLayout.fromPersisted(
+                    order = "REMOTE_CONNECTIONS,STORAGE,ACTIVE_SESSIONS,QUICK_ACCESS,BOOKMARKS,FOLDERS",
+                    hidden = "QUICK_ACCESS",
+                ),
+            )
+        }
+    }
+
+    @After
+    fun tearDown() {
+        runBlocking { preferences.setHomeLayout(HomeLayout.DEFAULT) }
+    }
+
+    @Test
+    fun homeUsesPersistedSectionVisibilityAndOrder() {
+        val viewModel = FileBrowserViewModel(application)
+        composeTestRule.setContent {
+            MaterialTheme {
+                HomeScreen(
+                    viewModel = viewModel,
+                    onNavigateToBrowser = {},
+                    onNavigateToSession = { _, _ -> },
+                    onNavigateToConnections = {},
+                    onNavigateToTrash = {},
+                    onNavigateToSettings = {},
+                    onOpenSafTree = {},
+                    hasAllFilesAccess = true,
+                    onRequestAllFilesAccess = {},
+                )
+            }
+        }
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            viewModel.homeLayout.value.visibleSections.first() == HomeSection.REMOTE_CONNECTIONS
+        }
+
+        composeTestRule.onNodeWithText("Quick Access").assertDoesNotExist()
+        composeTestRule.onNodeWithContentDescription("Settings").assertIsDisplayed()
+        val remoteTop = composeTestRule.onNodeWithText("Remote Connections")
+            .fetchSemanticsNode().boundsInRoot.top
+        val storageTop = composeTestRule.onNodeWithText("Storage")
+            .fetchSemanticsNode().boundsInRoot.top
+        assertTrue("Remote Connections should render before Storage", remoteTop < storageTop)
+    }
+}

--- a/app/src/androidTest/java/com/voyagerfiles/ui/screens/HomeLayoutSettingsTest.kt
+++ b/app/src/androidTest/java/com/voyagerfiles/ui/screens/HomeLayoutSettingsTest.kt
@@ -66,7 +66,7 @@ class HomeLayoutSettingsTest {
             .assertIsOn()
             .performClick()
         composeTestRule.waitUntil(timeoutMillis = 10_000) {
-            HomeSection.QUICK_ACCESS in viewModel.homeLayout.value.hiddenSections
+            HomeSection.QUICK_ACCESS in (viewModel.homeLayout.value?.hiddenSections ?: emptySet())
         }
         composeTestRule.onNodeWithContentDescription("Show Quick access on Home")
             .assertIsOff()
@@ -75,13 +75,13 @@ class HomeLayoutSettingsTest {
             .assertIsEnabled()
             .performClick()
         composeTestRule.waitUntil(timeoutMillis = 10_000) {
-            val order = viewModel.homeLayout.value.sectionOrder
+            val order = viewModel.homeLayout.value?.sectionOrder ?: return@waitUntil false
             order.indexOf(HomeSection.FOLDERS) < order.indexOf(HomeSection.BOOKMARKS)
         }
 
         val restoredViewModel = FileBrowserViewModel(application)
         composeTestRule.waitUntil(timeoutMillis = 10_000) {
-            val restored = restoredViewModel.homeLayout.value
+            val restored = restoredViewModel.homeLayout.value ?: return@waitUntil false
             HomeSection.QUICK_ACCESS in restored.hiddenSections &&
                 restored.sectionOrder.indexOf(HomeSection.FOLDERS) <
                 restored.sectionOrder.indexOf(HomeSection.BOOKMARKS)

--- a/app/src/androidTest/java/com/voyagerfiles/ui/screens/HomeLayoutSettingsTest.kt
+++ b/app/src/androidTest/java/com/voyagerfiles/ui/screens/HomeLayoutSettingsTest.kt
@@ -1,0 +1,97 @@
+package com.voyagerfiles.ui.screens
+
+import android.app.Application
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.test.core.app.ApplicationProvider
+import com.voyagerfiles.data.local.PreferencesManager
+import com.voyagerfiles.data.model.HomeLayout
+import com.voyagerfiles.data.model.HomeSection
+import com.voyagerfiles.viewmodel.FileBrowserViewModel
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class HomeLayoutSettingsTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var application: Application
+    private lateinit var preferences: PreferencesManager
+
+    @Before
+    fun setUp() {
+        application = ApplicationProvider.getApplicationContext()
+        preferences = PreferencesManager(application)
+        runBlocking { preferences.setHomeLayout(HomeLayout.DEFAULT) }
+    }
+
+    @After
+    fun tearDown() {
+        runBlocking { preferences.setHomeLayout(HomeLayout.DEFAULT) }
+    }
+
+    @Test
+    fun editorPersistsVisibilityAndOrderingChanges() {
+        val viewModel = FileBrowserViewModel(application)
+        composeTestRule.setContent {
+            MaterialTheme {
+                SettingsScreen(
+                    viewModel = viewModel,
+                    onNavigateBack = {},
+                    hasAllFilesAccess = false,
+                    onRequestAllFilesAccess = {},
+                )
+            }
+        }
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            viewModel.homeLayout.value == HomeLayout.DEFAULT
+        }
+
+        composeTestRule.onNodeWithContentDescription("Move Storage up")
+            .performScrollTo()
+            .assertIsNotEnabled()
+        composeTestRule.onNodeWithContentDescription("Show Quick access on Home")
+            .performScrollTo()
+            .assertIsOn()
+            .performClick()
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            HomeSection.QUICK_ACCESS in viewModel.homeLayout.value.hiddenSections
+        }
+        composeTestRule.onNodeWithContentDescription("Show Quick access on Home")
+            .assertIsOff()
+        composeTestRule.onNodeWithContentDescription("Move Folders up")
+            .performScrollTo()
+            .assertIsEnabled()
+            .performClick()
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            val order = viewModel.homeLayout.value.sectionOrder
+            order.indexOf(HomeSection.FOLDERS) < order.indexOf(HomeSection.BOOKMARKS)
+        }
+
+        val restoredViewModel = FileBrowserViewModel(application)
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            val restored = restoredViewModel.homeLayout.value
+            HomeSection.QUICK_ACCESS in restored.hiddenSections &&
+                restored.sectionOrder.indexOf(HomeSection.FOLDERS) <
+                restored.sectionOrder.indexOf(HomeSection.BOOKMARKS)
+        }
+
+        composeTestRule.onNodeWithContentDescription("Reset Home layout")
+            .performScrollTo()
+            .performClick()
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            viewModel.homeLayout.value == HomeLayout.DEFAULT
+        }
+    }
+}

--- a/app/src/main/java/com/voyagerfiles/data/local/PreferencesManager.kt
+++ b/app/src/main/java/com/voyagerfiles/data/local/PreferencesManager.kt
@@ -156,6 +156,10 @@ class PreferencesManager(private val context: Context) {
         }
     }
 
+    suspend fun setHomeLayout(layout: HomeLayout) {
+        context.dataStore.edit { preferences -> saveHomeLayout(preferences, layout) }
+    }
+
     suspend fun setCustomColors(primary: Long, background: Long, surface: Long) {
         context.dataStore.edit { prefs ->
             prefs[Keys.CUSTOM_PRIMARY] = primary

--- a/app/src/main/java/com/voyagerfiles/data/local/PreferencesManager.kt
+++ b/app/src/main/java/com/voyagerfiles/data/local/PreferencesManager.kt
@@ -3,6 +3,7 @@ package com.voyagerfiles.data.local
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.longPreferencesKey
@@ -10,6 +11,8 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.voyagerfiles.data.model.SortBy
 import com.voyagerfiles.data.model.SortOrder
+import com.voyagerfiles.data.model.HomeLayout
+import com.voyagerfiles.data.model.HomeSection
 import com.voyagerfiles.data.model.SessionAutoCloseTimeout
 import com.voyagerfiles.data.model.ViewMode
 import com.voyagerfiles.ui.theme.AppTheme
@@ -31,6 +34,8 @@ class PreferencesManager(private val context: Context) {
         val DEFAULT_PATH = stringPreferencesKey("default_path")
         val AUTO_CLOSE_SESSIONS = booleanPreferencesKey("auto_close_sessions")
         val SESSION_AUTO_CLOSE_TIMEOUT = stringPreferencesKey("session_auto_close_timeout")
+        val HOME_SECTION_ORDER = stringPreferencesKey("home_section_order")
+        val HOME_HIDDEN_SECTIONS = stringPreferencesKey("home_hidden_sections")
         val CUSTOM_PRIMARY = longPreferencesKey("custom_primary")
         val CUSTOM_BACKGROUND = longPreferencesKey("custom_background")
         val CUSTOM_SURFACE = longPreferencesKey("custom_surface")
@@ -78,6 +83,8 @@ class PreferencesManager(private val context: Context) {
     val sessionAutoCloseTimeout: Flow<SessionAutoCloseTimeout> = context.dataStore.data.map { prefs ->
         SessionAutoCloseTimeout.fromName(prefs[Keys.SESSION_AUTO_CLOSE_TIMEOUT])
     }
+
+    val homeLayout: Flow<HomeLayout> = context.dataStore.data.map(::homeLayoutFromPreferences)
 
     val customPrimary: Flow<Long> = context.dataStore.data.map { prefs ->
         prefs[Keys.CUSTOM_PRIMARY] ?: 0xFF6750A4
@@ -131,11 +138,43 @@ class PreferencesManager(private val context: Context) {
         context.dataStore.edit { it[Keys.SESSION_AUTO_CLOSE_TIMEOUT] = timeout.name }
     }
 
+    suspend fun setHomeSectionVisible(section: HomeSection, visible: Boolean) {
+        context.dataStore.edit { preferences ->
+            saveHomeLayout(
+                preferences = preferences,
+                layout = homeLayoutFromPreferences(preferences).withVisibility(section, visible),
+            )
+        }
+    }
+
+    suspend fun moveHomeSection(section: HomeSection, offset: Int) {
+        context.dataStore.edit { preferences ->
+            saveHomeLayout(
+                preferences = preferences,
+                layout = homeLayoutFromPreferences(preferences).move(section, offset),
+            )
+        }
+    }
+
     suspend fun setCustomColors(primary: Long, background: Long, surface: Long) {
         context.dataStore.edit { prefs ->
             prefs[Keys.CUSTOM_PRIMARY] = primary
             prefs[Keys.CUSTOM_BACKGROUND] = background
             prefs[Keys.CUSTOM_SURFACE] = surface
         }
+    }
+
+    private fun homeLayoutFromPreferences(preferences: Preferences): HomeLayout =
+        HomeLayout.fromPersisted(
+            order = preferences[Keys.HOME_SECTION_ORDER],
+            hidden = preferences[Keys.HOME_HIDDEN_SECTIONS],
+        )
+
+    private fun saveHomeLayout(
+        preferences: MutablePreferences,
+        layout: HomeLayout,
+    ) {
+        preferences[Keys.HOME_SECTION_ORDER] = layout.persistedOrder
+        preferences[Keys.HOME_HIDDEN_SECTIONS] = layout.persistedHidden
     }
 }

--- a/app/src/main/java/com/voyagerfiles/data/model/HomeLayout.kt
+++ b/app/src/main/java/com/voyagerfiles/data/model/HomeLayout.kt
@@ -1,0 +1,68 @@
+package com.voyagerfiles.data.model
+
+enum class HomeSection(val label: String) {
+    STORAGE("Storage"),
+    ACTIVE_SESSIONS("Active sessions"),
+    QUICK_ACCESS("Quick access"),
+    REMOTE_CONNECTIONS("Remote connections"),
+    BOOKMARKS("Bookmarks"),
+    FOLDERS("Folders"),
+}
+
+data class HomeLayout(
+    val sectionOrder: List<HomeSection> = HomeSection.entries,
+    val hiddenSections: Set<HomeSection> = emptySet(),
+) {
+    init {
+        require(sectionOrder.size == HomeSection.entries.size)
+        require(sectionOrder.toSet() == HomeSection.entries.toSet())
+        require(hiddenSections.all { it in sectionOrder })
+    }
+
+    val visibleSections: List<HomeSection>
+        get() = sectionOrder.filterNot { it in hiddenSections }
+
+    val persistedOrder: String
+        get() = sectionOrder.joinToString(",") { it.name }
+
+    val persistedHidden: String
+        get() = sectionOrder.filter { it in hiddenSections }.joinToString(",") { it.name }
+
+    fun withVisibility(section: HomeSection, visible: Boolean): HomeLayout = copy(
+        hiddenSections = if (visible) hiddenSections - section else hiddenSections + section,
+    )
+
+    fun move(section: HomeSection, offset: Int): HomeLayout {
+        val currentIndex = sectionOrder.indexOf(section)
+        val targetIndex = (currentIndex + offset).coerceIn(sectionOrder.indices)
+        if (targetIndex == currentIndex) return this
+        val reordered = sectionOrder.toMutableList().apply {
+            removeAt(currentIndex)
+            add(targetIndex, section)
+        }
+        return copy(sectionOrder = reordered)
+    }
+
+    companion object {
+        val DEFAULT = HomeLayout()
+
+        fun fromPersisted(order: String?, hidden: String?): HomeLayout {
+            val persistedOrder = parseSections(order)
+            val normalizedOrder = buildList {
+                persistedOrder.forEach { section -> if (section !in this) add(section) }
+                HomeSection.entries.forEach { section -> if (section !in this) add(section) }
+            }
+            return HomeLayout(
+                sectionOrder = normalizedOrder,
+                hiddenSections = parseSections(hidden).toSet(),
+            )
+        }
+
+        private fun parseSections(value: String?): List<HomeSection> {
+            if (value.isNullOrBlank()) return emptyList()
+            return value.split(',').mapNotNull { name ->
+                HomeSection.entries.firstOrNull { it.name == name.trim() }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/voyagerfiles/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/voyagerfiles/ui/screens/HomeScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.voyagerfiles.data.model.FileItem
 import com.voyagerfiles.data.model.FileSource
+import com.voyagerfiles.data.model.HomeSection
 import com.voyagerfiles.util.FileUtils
 import com.voyagerfiles.util.StorageInfo
 import com.voyagerfiles.util.StorageVolumeInfo
@@ -78,6 +79,7 @@ fun HomeScreen(
     val bookmarks by viewModel.bookmarks.collectAsState()
     val sessions by viewModel.sessions.collectAsState()
     val activeSession by viewModel.activeSession.collectAsState()
+    val homeLayout by viewModel.homeLayout.collectAsState()
     val context = LocalContext.current
     val safTreeLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.OpenDocumentTree(),
@@ -125,247 +127,261 @@ fun HomeScreen(
             item {
                 Spacer(modifier = Modifier.height(4.dp))
             }
-            if (hasAllFilesAccess) {
-                item {
-                    Text(
-                        "Storage",
-                        style = MaterialTheme.typography.titleSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-                items(
-                    items = storageVolumes,
-                    key = { "${it.description}:${it.path}:${it.isPrimary}" },
-                ) { volume ->
-                    StorageVolumeCard(
-                        volume = volume,
-                        storageInfo = volume.path?.let(storageInfoByPath::get),
-                        onClick = { volume.path?.let(onNavigateToBrowser) },
-                    )
-                }
-            } else {
-                item {
-                    Card(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable(onClick = onRequestAllFilesAccess),
-                        colors = CardDefaults.cardColors(
-                            containerColor = MaterialTheme.colorScheme.primaryContainer,
-                        ),
-                    ) {
-                        Column(modifier = Modifier.padding(16.dp)) {
-                            Text(
-                                "Limited storage access",
-                                style = MaterialTheme.typography.titleMedium,
-                                color = MaterialTheme.colorScheme.onPrimaryContainer,
-                            )
-                            Text(
-                                "Document trees and remote servers remain available. Grant full access to browse device storage directly.",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onPrimaryContainer,
-                            )
+            homeLayout.visibleSections.forEach { section ->
+                when (section) {
+                    HomeSection.STORAGE -> {
+                        if (hasAllFilesAccess) {
+                            item(key = "storage-header") {
+                                Text(
+                                    "Storage",
+                                    style = MaterialTheme.typography.titleSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                            items(
+                                items = storageVolumes,
+                                key = { "storage:${it.description}:${it.path}:${it.isPrimary}" },
+                            ) { volume ->
+                                StorageVolumeCard(
+                                    volume = volume,
+                                    storageInfo = volume.path?.let(storageInfoByPath::get),
+                                    onClick = { volume.path?.let(onNavigateToBrowser) },
+                                )
+                            }
+                        } else {
+                            item(key = "limited-storage") {
+                                Card(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .clickable(onClick = onRequestAllFilesAccess),
+                                    colors = CardDefaults.cardColors(
+                                        containerColor = MaterialTheme.colorScheme.primaryContainer,
+                                    ),
+                                ) {
+                                    Column(modifier = Modifier.padding(16.dp)) {
+                                        Text(
+                                            "Limited storage access",
+                                            style = MaterialTheme.typography.titleMedium,
+                                            color = MaterialTheme.colorScheme.onPrimaryContainer,
+                                        )
+                                        Text(
+                                            "Document trees and remote servers remain available. Grant full access to browse device storage directly.",
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onPrimaryContainer,
+                                        )
+                                    }
+                                }
+                            }
+                        }
+
+                        item(key = "document-tree") {
+                            SafAccessCard(onClick = { safTreeLauncher.launch(null) })
+                        }
+
+                        if (hasAllFilesAccess) {
+                            item(key = "trash") {
+                                Card(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .clickable(onClick = onNavigateToTrash),
+                                    colors = CardDefaults.cardColors(
+                                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                                    ),
+                                ) {
+                                    Row(
+                                        modifier = Modifier.padding(16.dp),
+                                        verticalAlignment = Alignment.CenterVertically,
+                                    ) {
+                                        Icon(
+                                            Icons.Filled.DeleteOutline,
+                                            contentDescription = null,
+                                            modifier = Modifier.size(28.dp),
+                                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        )
+                                        Spacer(modifier = Modifier.width(12.dp))
+                                        Column {
+                                            Text("Trash", style = MaterialTheme.typography.titleMedium)
+                                            Text(
+                                                "Restore or permanently delete local items",
+                                                style = MaterialTheme.typography.bodySmall,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            )
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
-                }
-            }
 
-            item {
-                SafAccessCard(onClick = { safTreeLauncher.launch(null) })
-            }
-
-            if (hasAllFilesAccess) {
-                item {
-                    Card(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable(onClick = onNavigateToTrash),
-                        colors = CardDefaults.cardColors(
-                            containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                        ),
-                    ) {
-                        Row(
-                            modifier = Modifier.padding(16.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Icon(
-                                Icons.Filled.DeleteOutline,
-                                contentDescription = null,
-                                modifier = Modifier.size(28.dp),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                            Spacer(modifier = Modifier.width(12.dp))
-                            Column {
-                                Text("Trash", style = MaterialTheme.typography.titleMedium)
+                    HomeSection.ACTIVE_SESSIONS -> {
+                        if (visibleSessions.isNotEmpty()) {
+                            item(key = "active-sessions-header") {
                                 Text(
-                                    "Restore or permanently delete local items",
-                                    style = MaterialTheme.typography.bodySmall,
+                                    "Active Sessions",
+                                    style = MaterialTheme.typography.titleSmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.padding(top = 8.dp),
+                                )
+                            }
+                            items(visibleSessions, key = { "session:${it.id}" }) { session ->
+                                ActiveSessionRow(
+                                    session = session,
+                                    isActive = session.id == activeSession?.id,
+                                    onClick = { onNavigateToSession(session.id, session.currentPath) },
                                 )
                             }
                         }
                     }
-                }
-            }
 
-            if (visibleSessions.isNotEmpty()) {
-                item {
-                    Text(
-                        "Active Sessions",
-                        style = MaterialTheme.typography.titleSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(top = 8.dp),
-                    )
-                }
-                items(visibleSessions, key = { it.id }) { session ->
-                    ActiveSessionRow(
-                        session = session,
-                        isActive = session.id == activeSession?.id,
-                        onClick = { onNavigateToSession(session.id, session.currentPath) },
-                    )
-                }
-            }
+                    HomeSection.QUICK_ACCESS -> {
+                        if (hasAllFilesAccess) {
+                            item(key = "quick-access-header") {
+                                Text(
+                                    "Quick Access",
+                                    style = MaterialTheme.typography.titleSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.padding(top = 8.dp),
+                                )
+                            }
 
-            if (hasAllFilesAccess) {
-                item {
-                    Text(
-                        "Quick Access",
-                        style = MaterialTheme.typography.titleSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(top = 8.dp),
-                    )
-                }
-
-                item {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        QuickAccessCard(
-                            icon = Icons.Filled.Download,
-                            label = "Downloads",
-                            modifier = Modifier.weight(1f),
-                            onClick = { onNavigateToBrowser(directories.find { it.name == "Downloads" }?.path ?: "/storage/emulated/0/Download") },
-                        )
-                        QuickAccessCard(
-                            icon = Icons.Filled.Image,
-                            label = "Pictures",
-                            modifier = Modifier.weight(1f),
-                            onClick = { onNavigateToBrowser(directories.find { it.name == "Pictures" }?.path ?: "/storage/emulated/0/Pictures") },
-                        )
-                        QuickAccessCard(
-                            icon = Icons.Filled.MusicNote,
-                            label = "Music",
-                            modifier = Modifier.weight(1f),
-                            onClick = { onNavigateToBrowser(directories.find { it.name == "Music" }?.path ?: "/storage/emulated/0/Music") },
-                        )
-                        QuickAccessCard(
-                            icon = Icons.Filled.VideoLibrary,
-                            label = "Videos",
-                            modifier = Modifier.weight(1f),
-                            onClick = { onNavigateToBrowser(directories.find { it.name == "Movies" }?.path ?: "/storage/emulated/0/Movies") },
-                        )
-                    }
-                }
-            }
-
-            // Network
-            item {
-                Card(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable { onNavigateToConnections() },
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                    ),
-                ) {
-                    Row(
-                        modifier = Modifier.padding(16.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Icon(
-                            Icons.Filled.Cloud,
-                            contentDescription = null,
-                            modifier = Modifier.size(28.dp),
-                            tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                        )
-                        Spacer(modifier = Modifier.width(12.dp))
-                        Column {
-                            Text(
-                                "Remote Connections",
-                                style = MaterialTheme.typography.titleMedium,
-                                color = MaterialTheme.colorScheme.onSecondaryContainer,
-                            )
-                            Text(
-                                "SFTP, FTP, SMB, WebDAV",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
-                            )
+                            item(key = "quick-access-cards") {
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                ) {
+                                    QuickAccessCard(
+                                        icon = Icons.Filled.Download,
+                                        label = "Downloads",
+                                        modifier = Modifier.weight(1f),
+                                        onClick = { onNavigateToBrowser(directories.find { it.name == "Downloads" }?.path ?: "/storage/emulated/0/Download") },
+                                    )
+                                    QuickAccessCard(
+                                        icon = Icons.Filled.Image,
+                                        label = "Pictures",
+                                        modifier = Modifier.weight(1f),
+                                        onClick = { onNavigateToBrowser(directories.find { it.name == "Pictures" }?.path ?: "/storage/emulated/0/Pictures") },
+                                    )
+                                    QuickAccessCard(
+                                        icon = Icons.Filled.MusicNote,
+                                        label = "Music",
+                                        modifier = Modifier.weight(1f),
+                                        onClick = { onNavigateToBrowser(directories.find { it.name == "Music" }?.path ?: "/storage/emulated/0/Music") },
+                                    )
+                                    QuickAccessCard(
+                                        icon = Icons.Filled.VideoLibrary,
+                                        label = "Videos",
+                                        modifier = Modifier.weight(1f),
+                                        onClick = { onNavigateToBrowser(directories.find { it.name == "Movies" }?.path ?: "/storage/emulated/0/Movies") },
+                                    )
+                                }
+                            }
                         }
                     }
-                }
-            }
 
-            // Bookmarks
-            if (hasAllFilesAccess && localBookmarks.isNotEmpty()) {
-                item {
-                    Text(
-                        "Bookmarks",
-                        style = MaterialTheme.typography.titleSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(top = 8.dp),
-                    )
-                }
-                items(localBookmarks) { bookmark ->
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable { onNavigateToBrowser(bookmark.path) }
-                            .padding(vertical = 8.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Icon(
-                            Icons.Filled.Bookmark,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.primary,
-                        )
-                        Spacer(modifier = Modifier.width(12.dp))
-                        Column {
-                            Text(bookmark.name, style = MaterialTheme.typography.bodyLarge)
-                            Text(
-                                bookmark.path,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
+                    HomeSection.REMOTE_CONNECTIONS -> {
+                        item(key = "remote-connections") {
+                            Card(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable { onNavigateToConnections() },
+                                colors = CardDefaults.cardColors(
+                                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                                ),
+                            ) {
+                                Row(
+                                    modifier = Modifier.padding(16.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                ) {
+                                    Icon(
+                                        Icons.Filled.Cloud,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(28.dp),
+                                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                                    )
+                                    Spacer(modifier = Modifier.width(12.dp))
+                                    Column {
+                                        Text(
+                                            "Remote Connections",
+                                            style = MaterialTheme.typography.titleMedium,
+                                            color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                        )
+                                        Text(
+                                            "SFTP, FTP, SMB, WebDAV",
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
+                                        )
+                                    }
+                                }
+                            }
                         }
                     }
-                }
-            }
 
-            if (hasAllFilesAccess) {
-                item {
-                    Text(
-                        "Folders",
-                        style = MaterialTheme.typography.titleSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(top = 8.dp),
-                    )
-                }
-                items(directories) { dir ->
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable { onNavigateToBrowser(dir.path) }
-                            .padding(vertical = 10.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Icon(
-                            if (dir.name == "Internal Storage") Icons.Filled.PhoneAndroid else Icons.Filled.Folder,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.size(24.dp),
-                        )
-                        Spacer(modifier = Modifier.width(16.dp))
-                        Text(dir.name, style = MaterialTheme.typography.bodyLarge)
+                    HomeSection.BOOKMARKS -> {
+                        if (hasAllFilesAccess && localBookmarks.isNotEmpty()) {
+                            item(key = "bookmarks-header") {
+                                Text(
+                                    "Bookmarks",
+                                    style = MaterialTheme.typography.titleSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.padding(top = 8.dp),
+                                )
+                            }
+                            items(localBookmarks, key = { "bookmark:${it.id}" }) { bookmark ->
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .clickable { onNavigateToBrowser(bookmark.path) }
+                                        .padding(vertical = 8.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                ) {
+                                    Icon(
+                                        Icons.Filled.Bookmark,
+                                        contentDescription = null,
+                                        tint = MaterialTheme.colorScheme.primary,
+                                    )
+                                    Spacer(modifier = Modifier.width(12.dp))
+                                    Column {
+                                        Text(bookmark.name, style = MaterialTheme.typography.bodyLarge)
+                                        Text(
+                                            bookmark.path,
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    HomeSection.FOLDERS -> {
+                        if (hasAllFilesAccess) {
+                            item(key = "folders-header") {
+                                Text(
+                                    "Folders",
+                                    style = MaterialTheme.typography.titleSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.padding(top = 8.dp),
+                                )
+                            }
+                            items(directories, key = { "folder:${it.path}" }) { dir ->
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .clickable { onNavigateToBrowser(dir.path) }
+                                        .padding(vertical = 10.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                ) {
+                                    Icon(
+                                        if (dir.name == "Internal Storage") Icons.Filled.PhoneAndroid else Icons.Filled.Folder,
+                                        contentDescription = null,
+                                        tint = MaterialTheme.colorScheme.primary,
+                                        modifier = Modifier.size(24.dp),
+                                    )
+                                    Spacer(modifier = Modifier.width(16.dp))
+                                    Text(dir.name, style = MaterialTheme.typography.bodyLarge)
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/voyagerfiles/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/voyagerfiles/ui/screens/HomeScreen.kt
@@ -127,7 +127,7 @@ fun HomeScreen(
             item {
                 Spacer(modifier = Modifier.height(4.dp))
             }
-            homeLayout.visibleSections.forEach { section ->
+            homeLayout?.visibleSections?.forEach { section ->
                 when (section) {
                     HomeSection.STORAGE -> {
                         if (hasAllFilesAccess) {

--- a/app/src/main/java/com/voyagerfiles/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/voyagerfiles/ui/screens/SettingsScreen.kt
@@ -178,70 +178,72 @@ fun SettingsScreen(
 
             Spacer(modifier = Modifier.height(24.dp))
 
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(
-                    "Home layout",
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.primary,
-                )
-                TextButton(
-                    onClick = viewModel::resetHomeLayout,
-                    modifier = Modifier.semantics {
-                        contentDescription = "Reset Home layout"
-                    },
-                ) {
-                    Text("Reset")
-                }
-            }
-            Text(
-                "Choose which sections appear and arrange their order",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-
-            homeLayout.sectionOrder.forEachIndexed { index, section ->
+            homeLayout?.let { layout ->
                 Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 4.dp),
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Text(
-                        section.label,
-                        style = MaterialTheme.typography.bodyLarge,
-                        modifier = Modifier.weight(1f),
+                        "Home layout",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.primary,
                     )
-                    Switch(
-                        checked = section !in homeLayout.hiddenSections,
-                        onCheckedChange = { visible ->
-                            viewModel.setHomeSectionVisible(section, visible)
-                        },
+                    TextButton(
+                        onClick = viewModel::resetHomeLayout,
                         modifier = Modifier.semantics {
-                            contentDescription = "Show ${section.label} on Home"
+                            contentDescription = "Reset Home layout"
                         },
-                    )
-                    IconButton(
-                        onClick = { viewModel.moveHomeSection(section, -1) },
-                        enabled = index > 0,
                     ) {
-                        Icon(
-                            Icons.Filled.KeyboardArrowUp,
-                            contentDescription = "Move ${section.label} up",
-                        )
+                        Text("Reset")
                     }
-                    IconButton(
-                        onClick = { viewModel.moveHomeSection(section, 1) },
-                        enabled = index < homeLayout.sectionOrder.lastIndex,
+                }
+                Text(
+                    "Choose which sections appear and arrange their order",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+
+                layout.sectionOrder.forEachIndexed { index, section ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        Icon(
-                            Icons.Filled.KeyboardArrowDown,
-                            contentDescription = "Move ${section.label} down",
+                        Text(
+                            section.label,
+                            style = MaterialTheme.typography.bodyLarge,
+                            modifier = Modifier.weight(1f),
                         )
+                        Switch(
+                            checked = section !in layout.hiddenSections,
+                            onCheckedChange = { visible ->
+                                viewModel.setHomeSectionVisible(section, visible)
+                            },
+                            modifier = Modifier.semantics {
+                                contentDescription = "Show ${section.label} on Home"
+                            },
+                        )
+                        IconButton(
+                            onClick = { viewModel.moveHomeSection(section, -1) },
+                            enabled = index > 0,
+                        ) {
+                            Icon(
+                                Icons.Filled.KeyboardArrowUp,
+                                contentDescription = "Move ${section.label} up",
+                            )
+                        }
+                        IconButton(
+                            onClick = { viewModel.moveHomeSection(section, 1) },
+                            enabled = index < layout.sectionOrder.lastIndex,
+                        ) {
+                            Icon(
+                                Icons.Filled.KeyboardArrowDown,
+                                contentDescription = "Move ${section.label} down",
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/voyagerfiles/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/voyagerfiles/ui/screens/SettingsScreen.kt
@@ -21,6 +21,8 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -87,6 +89,7 @@ fun SettingsScreen(
     val useTrash by viewModel.useTrash.collectAsState()
     val autoCloseSessions by viewModel.autoCloseSessions.collectAsState()
     val sessionAutoCloseTimeout by viewModel.sessionAutoCloseTimeout.collectAsState()
+    val homeLayout by viewModel.homeLayout.collectAsState()
     var selectedThemeCategoryIndex by rememberSaveable { mutableIntStateOf(0) }
     var timeoutMenuExpanded by rememberSaveable { mutableStateOf(false) }
     val selectedThemeCategory = themeCategories[selectedThemeCategoryIndex]
@@ -171,6 +174,76 @@ fun SettingsScreen(
             Spacer(modifier = Modifier.height(12.dp))
             Button(onClick = onRequestAllFilesAccess) {
                 Text(if (hasAllFilesAccess) "Manage access" else "Grant full access")
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    "Home layout",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                TextButton(
+                    onClick = viewModel::resetHomeLayout,
+                    modifier = Modifier.semantics {
+                        contentDescription = "Reset Home layout"
+                    },
+                ) {
+                    Text("Reset")
+                }
+            }
+            Text(
+                "Choose which sections appear and arrange their order",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+
+            homeLayout.sectionOrder.forEachIndexed { index, section ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        section.label,
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Switch(
+                        checked = section !in homeLayout.hiddenSections,
+                        onCheckedChange = { visible ->
+                            viewModel.setHomeSectionVisible(section, visible)
+                        },
+                        modifier = Modifier.semantics {
+                            contentDescription = "Show ${section.label} on Home"
+                        },
+                    )
+                    IconButton(
+                        onClick = { viewModel.moveHomeSection(section, -1) },
+                        enabled = index > 0,
+                    ) {
+                        Icon(
+                            Icons.Filled.KeyboardArrowUp,
+                            contentDescription = "Move ${section.label} up",
+                        )
+                    }
+                    IconButton(
+                        onClick = { viewModel.moveHomeSection(section, 1) },
+                        enabled = index < homeLayout.sectionOrder.lastIndex,
+                    ) {
+                        Icon(
+                            Icons.Filled.KeyboardArrowDown,
+                            contentDescription = "Move ${section.label} down",
+                        )
+                    }
+                }
             }
 
             Spacer(modifier = Modifier.height(24.dp))

--- a/app/src/main/java/com/voyagerfiles/viewmodel/FileBrowserViewModel.kt
+++ b/app/src/main/java/com/voyagerfiles/viewmodel/FileBrowserViewModel.kt
@@ -101,11 +101,7 @@ class FileBrowserViewModel(application: Application) : AndroidViewModel(applicat
         SharingStarted.Eagerly,
         SessionAutoCloseTimeout.FIFTEEN_MINUTES,
     )
-    val homeLayout = prefs.homeLayout.stateIn(
-        viewModelScope,
-        SharingStarted.Eagerly,
-        HomeLayout.DEFAULT,
-    )
+    val homeLayout = prefs.homeLayout.stateInWithLoading(viewModelScope)
     val limitedAccessAccepted = prefs.limitedAccessAccepted.stateIn(viewModelScope, SharingStarted.Eagerly, false)
     val connections = connectionRepository.connections.stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
     val bookmarks = bookmarkDao.getAllBookmarks().stateIn(viewModelScope, SharingStarted.Lazily, emptyList())

--- a/app/src/main/java/com/voyagerfiles/viewmodel/FileBrowserViewModel.kt
+++ b/app/src/main/java/com/voyagerfiles/viewmodel/FileBrowserViewModel.kt
@@ -13,6 +13,8 @@ import com.voyagerfiles.data.model.ConnectionProtocol
 import com.voyagerfiles.data.model.FileItem
 import com.voyagerfiles.data.model.FileSource
 import com.voyagerfiles.data.model.FileTypeFilter
+import com.voyagerfiles.data.model.HomeLayout
+import com.voyagerfiles.data.model.HomeSection
 import com.voyagerfiles.data.model.RemoteConnection
 import com.voyagerfiles.data.model.SessionAutoCloseTimeout
 import com.voyagerfiles.data.model.SortBy
@@ -98,6 +100,11 @@ class FileBrowserViewModel(application: Application) : AndroidViewModel(applicat
         viewModelScope,
         SharingStarted.Eagerly,
         SessionAutoCloseTimeout.FIFTEEN_MINUTES,
+    )
+    val homeLayout = prefs.homeLayout.stateIn(
+        viewModelScope,
+        SharingStarted.Eagerly,
+        HomeLayout.DEFAULT,
     )
     val limitedAccessAccepted = prefs.limitedAccessAccepted.stateIn(viewModelScope, SharingStarted.Eagerly, false)
     val connections = connectionRepository.connections.stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
@@ -884,6 +891,18 @@ class FileBrowserViewModel(application: Application) : AndroidViewModel(applicat
 
     fun setSessionAutoCloseTimeout(timeout: SessionAutoCloseTimeout) {
         viewModelScope.launch { prefs.setSessionAutoCloseTimeout(timeout) }
+    }
+
+    fun setHomeSectionVisible(section: HomeSection, visible: Boolean) {
+        viewModelScope.launch { prefs.setHomeSectionVisible(section, visible) }
+    }
+
+    fun moveHomeSection(section: HomeSection, offset: Int) {
+        viewModelScope.launch { prefs.moveHomeSection(section, offset) }
+    }
+
+    fun resetHomeLayout() {
+        viewModelScope.launch { prefs.setHomeLayout(HomeLayout.DEFAULT) }
     }
 
     fun setLimitedAccessAccepted(accepted: Boolean) {

--- a/app/src/main/java/com/voyagerfiles/viewmodel/HomeLayoutState.kt
+++ b/app/src/main/java/com/voyagerfiles/viewmodel/HomeLayoutState.kt
@@ -1,0 +1,13 @@
+package com.voyagerfiles.viewmodel
+
+import com.voyagerfiles.data.model.HomeLayout
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+
+internal fun Flow<HomeLayout>.stateInWithLoading(scope: CoroutineScope): StateFlow<HomeLayout?> {
+    val nullableLayouts: Flow<HomeLayout?> = this
+    return nullableLayouts.stateIn(scope, SharingStarted.Eagerly, null)
+}

--- a/app/src/test/java/com/voyagerfiles/data/model/HomeLayoutTest.kt
+++ b/app/src/test/java/com/voyagerfiles/data/model/HomeLayoutTest.kt
@@ -1,0 +1,97 @@
+package com.voyagerfiles.data.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HomeLayoutTest {
+
+    @Test
+    fun defaultLayoutMatchesExistingHomeOrder() {
+        assertEquals(
+            listOf(
+                HomeSection.STORAGE,
+                HomeSection.ACTIVE_SESSIONS,
+                HomeSection.QUICK_ACCESS,
+                HomeSection.REMOTE_CONNECTIONS,
+                HomeSection.BOOKMARKS,
+                HomeSection.FOLDERS,
+            ),
+            HomeLayout.DEFAULT.sectionOrder,
+        )
+        assertEquals(HomeSection.entries, HomeLayout.DEFAULT.visibleSections)
+    }
+
+    @Test
+    fun persistedLayoutDropsUnknownsAndDuplicatesThenAppendsMissingSections() {
+        val layout = HomeLayout.fromPersisted(
+            order = "FOLDERS,UNKNOWN,FOLDERS,STORAGE",
+            hidden = "QUICK_ACCESS,REMOVED",
+        )
+
+        assertEquals(
+            listOf(
+                HomeSection.FOLDERS,
+                HomeSection.STORAGE,
+                HomeSection.ACTIVE_SESSIONS,
+                HomeSection.QUICK_ACCESS,
+                HomeSection.REMOTE_CONNECTIONS,
+                HomeSection.BOOKMARKS,
+            ),
+            layout.sectionOrder,
+        )
+        assertEquals(setOf(HomeSection.QUICK_ACCESS), layout.hiddenSections)
+    }
+
+    @Test
+    fun blankPersistenceUsesDefaultLayout() {
+        assertEquals(HomeLayout.DEFAULT, HomeLayout.fromPersisted(null, null))
+        assertEquals(HomeLayout.DEFAULT, HomeLayout.fromPersisted("", ""))
+    }
+
+    @Test
+    fun visibilityChangeKeepsSectionRecoverableInTheOrder() {
+        val hidden = HomeLayout.DEFAULT.withVisibility(HomeSection.QUICK_ACCESS, visible = false)
+
+        assertFalse(HomeSection.QUICK_ACCESS in hidden.visibleSections)
+        assertTrue(HomeSection.QUICK_ACCESS in hidden.sectionOrder)
+        assertEquals(
+            HomeLayout.DEFAULT,
+            hidden.withVisibility(HomeSection.QUICK_ACCESS, visible = true),
+        )
+    }
+
+    @Test
+    fun moveClampsAtBoundariesAndChangesOnlyOrder() {
+        assertEquals(
+            HomeLayout.DEFAULT,
+            HomeLayout.DEFAULT.move(HomeSection.STORAGE, offset = -1),
+        )
+        assertEquals(
+            HomeLayout.DEFAULT,
+            HomeLayout.DEFAULT.move(HomeSection.FOLDERS, offset = 1),
+        )
+
+        val moved = HomeLayout.DEFAULT
+            .withVisibility(HomeSection.FOLDERS, visible = false)
+            .move(HomeSection.FOLDERS, offset = -1)
+
+        assertEquals(HomeSection.FOLDERS, moved.sectionOrder[moved.sectionOrder.lastIndex - 1])
+        assertEquals(setOf(HomeSection.FOLDERS), moved.hiddenSections)
+    }
+
+    @Test
+    fun persistenceRoundTripIsDeterministic() {
+        val layout = HomeLayout.DEFAULT
+            .move(HomeSection.FOLDERS, offset = -1)
+            .withVisibility(HomeSection.QUICK_ACCESS, visible = false)
+            .withVisibility(HomeSection.STORAGE, visible = false)
+
+        assertEquals(
+            layout,
+            HomeLayout.fromPersisted(layout.persistedOrder, layout.persistedHidden),
+        )
+        assertEquals("STORAGE,QUICK_ACCESS", layout.persistedHidden)
+    }
+}

--- a/app/src/test/java/com/voyagerfiles/viewmodel/HomeLayoutStateTest.kt
+++ b/app/src/test/java/com/voyagerfiles/viewmodel/HomeLayoutStateTest.kt
@@ -1,0 +1,31 @@
+package com.voyagerfiles.viewmodel
+
+import com.voyagerfiles.data.model.HomeLayout
+import com.voyagerfiles.data.model.HomeSection
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.yield
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class HomeLayoutStateTest {
+
+    @Test
+    fun remainsLoadingUntilPersistedLayoutArrives() = runBlocking {
+        val releasePreferences = CompletableDeferred<Unit>()
+        val persisted = HomeLayout.DEFAULT.withVisibility(HomeSection.QUICK_ACCESS, visible = false)
+        val state = flow {
+            releasePreferences.await()
+            emit(persisted)
+        }.stateInWithLoading(this)
+
+        assertNull(state.value)
+
+        releasePreferences.complete(Unit)
+        yield()
+
+        assertEquals(persisted, state.value)
+    }
+}

--- a/docs/superpowers/plans/2026-07-19-custom-home-layout.md
+++ b/docs/superpowers/plans/2026-07-19-custom-home-layout.md
@@ -1,0 +1,64 @@
+# Custom Home Layout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Let users hide and reorder logical Home sections while preserving Voyager's current layout by default.
+
+**Architecture:** A normalized `HomeLayout` value owns complete section order and visibility. Preferences DataStore updates it atomically, FileBrowserViewModel exposes it, Settings edits it with switches and move buttons, and HomeScreen emits existing section groups in the configured order.
+
+**Tech Stack:** Kotlin 2.1, Android DataStore Preferences, Jetpack Compose Material 3, Kotlin coroutines, JUnit 4, AndroidX Compose UI tests.
+
+## Global Constraints
+
+- Keep the default Home screen visually and behaviorally unchanged.
+- Persist stable enum names and tolerate malformed or older stored values.
+- Keep all hidden sections recoverable in Settings.
+- Preserve storage-permission and dynamic-content gating.
+- Use accessible content descriptions for visibility and move controls.
+- Keep prose in Markdown as one paragraph per physical line and do not add AI-authorship markers.
+
+### Task 1: Model and persist a normalized Home layout
+
+**Files:**
+- Create: `app/src/main/java/com/voyagerfiles/data/model/HomeLayout.kt`
+- Modify: `app/src/main/java/com/voyagerfiles/data/local/PreferencesManager.kt`
+- Test: `app/src/test/java/com/voyagerfiles/data/model/HomeLayoutTest.kt`
+
+- [ ] Write failing tests for default order, duplicate and unknown persisted names, missing future sections, hidden-name parsing, visibility updates, and move boundaries.
+- [ ] Run the focused unit test and verify RED.
+- [ ] Implement `HomeSection`, `HomeLayout`, serialization, and atomic DataStore updates.
+- [ ] Run the focused unit test and verify GREEN.
+- [ ] Commit the model and persistence boundary.
+
+### Task 2: Expose an accessible Home layout editor
+
+**Files:**
+- Modify: `app/src/main/java/com/voyagerfiles/viewmodel/FileBrowserViewModel.kt`
+- Modify: `app/src/main/java/com/voyagerfiles/ui/screens/SettingsScreen.kt`
+- Create: `app/src/androidTest/java/com/voyagerfiles/ui/screens/HomeLayoutSettingsTest.kt`
+
+- [ ] Write a failing Compose test that hides Quick Access, moves Folders upward, verifies boundary controls, and confirms the resulting layout in a new view model.
+- [ ] Expose `homeLayout`, `setHomeSectionVisible`, and `moveHomeSection` in the view model.
+- [ ] Add the ordered Settings rows with accessible switches and up/down controls.
+- [ ] Run the focused connected test and verify GREEN.
+- [ ] Commit the editor.
+
+### Task 3: Render Home from the configured layout
+
+**Files:**
+- Modify: `app/src/main/java/com/voyagerfiles/ui/screens/HomeScreen.kt`
+- Create: `app/src/androidTest/java/com/voyagerfiles/ui/screens/CustomHomeLayoutTest.kt`
+
+- [ ] Write a failing Compose test that hides Quick Access and places Folders before Remote Connections, then verifies absence and vertical ordering.
+- [ ] Extract the six existing Home groups into LazyListScope section emitters and iterate visible configured sections.
+- [ ] Run the focused connected test and verify GREEN.
+- [ ] Commit configurable Home rendering.
+
+### Task 4: Verify and publish
+
+- [ ] Run `git diff --check master...HEAD`.
+- [ ] Run `./gradlew --no-daemon --max-workers=2 -Dorg.gradle.jvmargs='-Xmx4096m -Dfile.encoding=UTF-8' testDebugUnitTest lintDebug assembleDebug assembleRelease --rerun-tasks --stacktrace`.
+- [ ] Run `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew connectedDebugAndroidTest --rerun-tasks --stacktrace`.
+- [ ] Manually inspect default and customized layouts on the connected Android 16 device.
+- [ ] Request an independent diff review, address actionable findings, and repeat affected gates.
+- [ ] Push the branch, open a draft pull request with `Fixes #19`, wait for final-head CI, then mark ready and merge.

--- a/docs/superpowers/specs/2026-07-19-custom-home-layout-design.md
+++ b/docs/superpowers/specs/2026-07-19-custom-home-layout-design.md
@@ -1,0 +1,47 @@
+# Custom Home Layout Design
+
+## Problem
+
+Voyager's Home screen has a fixed sequence of storage access, active sessions, quick access, remote connections, bookmarks, and folders. Issue #19 asks users to be able to remove or move Home sections, or alternatively to replace Home with a chosen startup directory. The reporter did not identify a preferred outcome, so this design implements complete section visibility and ordering while preserving the existing layout by default.
+
+## Requirements
+
+- Let users show or hide every logical Home section from Settings.
+- Let users move every section up or down with controls that work with touch and accessibility services.
+- Preserve the current Home sequence for existing installations until a user changes it.
+- Persist visibility and ordering across process restarts.
+- Recover safely from unknown, duplicate, removed, or newly added persisted section names.
+- Keep Settings reachable regardless of which sections are hidden.
+- Preserve existing permission gating and dynamic-content rules inside each section.
+
+## Section Model
+
+`HomeSection` defines six stable persisted identifiers: Storage, Active Sessions, Quick Access, Remote Connections, Bookmarks, and Folders. Storage contains the current storage-volume or limited-access card, Document Tree card, and Trash card. The remaining sections map to their existing Home content.
+
+`HomeLayout` contains the complete ordered section list and a hidden-section set. Its persistence parser drops unknown and duplicate names, then appends any known section missing from stored order. This means a section introduced by a future release appears at the end instead of disappearing. Unknown hidden names are ignored. Pure operations return a new normalized layout when a section is moved or its visibility changes.
+
+## Persistence and State
+
+Preferences DataStore stores the section order and hidden set as comma-separated enum names. `PreferencesManager.homeLayout` decodes both keys together. Visibility and move updates use DataStore's atomic `edit` block and decode the latest stored layout inside that block, preventing rapid controls from overwriting an earlier change. `FileBrowserViewModel` exposes the layout as an eager StateFlow and delegates Settings actions to these atomic updates.
+
+## Settings UI
+
+Settings adds a Home layout section with one row per section in its current order. Each row has a visibility switch and Move up and Move down icon buttons. The first row's up button and last row's down button are disabled. Hidden rows remain in the editor and can still be reordered or restored. Content descriptions include the section label and action.
+
+## Home Rendering
+
+HomeScreen collects `homeLayout`, iterates its visible ordered sections inside the existing LazyColumn, and emits the current content for each section. Hiding a section removes its entire group, including its header. Reordering only changes group placement. A chosen section can still render no content when its existing conditions are unmet, such as Active Sessions with no sessions or Bookmarks with no bookmarks. The Settings icon remains in the fixed top app bar.
+
+## Testing
+
+- Unit-test default order, malformed persistence normalization, visibility changes, move boundaries, and round-trip serialization.
+- Add a Settings Compose test that hides a section, reorders another section, verifies accessibility controls, and confirms persistence in a new view model.
+- Add a Home Compose test that persists a custom layout, verifies a hidden section is absent, and compares rendered bounds to confirm section ordering.
+- Run the full unit, lint, debug assembly, release assembly, and connected-device gates.
+- Manually inspect the Home layout editor and a customized Home screen on the connected Android 16 device.
+
+## Non-goals
+
+- Replacing Home with a startup folder is not included because the issue explicitly offered section customization as an alternative outcome.
+- Drag-and-drop gestures are not included; explicit move buttons provide deterministic and accessible ordering.
+- Content inside a section is not individually customizable.


### PR DESCRIPTION
## Summary

- persist Home section visibility and ordering with forward-compatible preference parsing
- add accessible Settings controls to show, hide, move, and reset all Home sections
- render Home from the saved layout while preserving storage-permission behavior and stable list identity
- defer layout-dependent UI until saved preferences load to prevent startup flashes

## Testing

- `./gradlew --no-daemon --max-workers=2 -Dorg.gradle.jvmargs="-Xmx4096m -Dfile.encoding=UTF-8" clean testDebugUnitTest lintDebug assembleDebug assembleRelease --stacktrace`
- `ANDROID_SERIAL=192.168.27.167:5555 ./gradlew --no-daemon --max-workers=2 -Dorg.gradle.jvmargs="-Xmx4096m -Dfile.encoding=UTF-8" connectedDebugAndroidTest --rerun-tasks --stacktrace`
- manually verified hide, return-to-Home update, reset, default layout, and all controls on an Android 16 device

Fixes #19