### PR TITLE
Prepare Voyager 1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ An open-source Android file manager for local storage, document trees, SFTP, FTP
 - Filter a folder by directories, images, videos, audio, documents, archives, or Android packages.
 - Select visible results, share local or document-tree files, inspect file details, copy, move, rename, delete, and create files and folders, including cross-provider transfers.
 - Choose Trash or permanent deletion for each direct-local operation, restore recoverable per-volume Trash items, or disable Trash in Settings.
-- Bookmark local folders, open common media locations, and keep several local, document-tree, or remote browser sessions open.
-- Connect to SFTP, FTP, SMB, and WebDAV servers and download remote files or directories to Android's Downloads folder.
+- Bookmark local folders, open common media locations, customize the visibility and order of Home sections, and keep several local, document-tree, or remote browser sessions open.
+- Automatically close inactive browser sessions after Voyager remains in the background for a chosen duration.
+- Connect to SFTP, FTP, SMB, and WebDAV servers, create remote files and folders, upload Android documents, and download remote files or directories to Android's Downloads folder.
 - Authenticate to SFTP with a password, keyboard-interactive authentication, a private key file, or an in-app generated key pair.
 - Choose from 20 included color schemes, including AMOLED black and high-contrast options, with Material You dynamic colors on Android 12 and later.
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,8 +28,8 @@ android {
         applicationId = "com.voyagerfiles"
         minSdk = 26
         targetSdk = 35
-        versionCode = 12
-        versionName = "1.4.0"
+        versionCode = 13
+        versionName = "1.5.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/fastlane/metadata/android/en-US/changelogs/13.txt
+++ b/fastlane/metadata/android/en-US/changelogs/13.txt
@@ -1,0 +1,6 @@
+Release 1.5.0:
+- Create files and folders and upload Android documents in SFTP, FTP, SMB, and WebDAV sessions
+- Automatically close inactive sessions after a chosen time in the background
+- Show, hide, reorder, and reset Home sections
+- Keep dark navigation backgrounds consistent during transitions
+- Reconnect stale FTP sessions before operations

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -11,14 +11,16 @@ Features:
 • SMB/CIFS network share browsing
 • WebDAV remote access
 • Copy and move files between local storage and a remote server, in both directions
+• Create remote files and folders, and upload documents through Android's system picker
 • Download remote files and folders to the device
 • Multiple browser sessions for local and remote locations, with a session switcher
+• Optional automatic closure of inactive sessions after Voyager remains in the background
 • Mounted external storage volumes, such as SD cards and USB/OTG, listed alongside internal storage
 • 20 built-in themes including Catppuccin, Nord, Solarized, Gruvbox, Rosé Pine, Tokyo Night, and High Contrast
 • Custom theme support
 • AMOLED black theme
 • List, compact list, and grid view modes
-• Bookmarks and quick access
+• Bookmarks, quick access, and customizable Home section visibility and order
 • Storage usage overview
 • Hidden files toggle
 • Multiple sort options (name, size, date, type)

--- a/metadata/en-US/changelogs/13.txt
+++ b/metadata/en-US/changelogs/13.txt
@@ -1,0 +1,6 @@
+Voyager 1.5.0:
+- Create files and folders and upload Android documents in SFTP, FTP, SMB, and WebDAV sessions
+- Automatically close inactive sessions after a chosen time in the background
+- Show, hide, reorder, and reset Home sections
+- Keep dark navigation backgrounds consistent during transitions
+- Reconnect stale FTP sessions before operations


### PR DESCRIPTION
## Summary

- bump Voyager to versionCode 13 and versionName 1.5.0
- add matching Fastlane and in-repository F-Droid changelogs
- update the README and store description for remote create/upload, inactive-session closure, and customizable Home sections

## Testing

- `./gradlew --no-daemon --max-workers=2 -Dorg.gradle.jvmargs="-Xmx4096m -Dfile.encoding=UTF-8" clean testDebugUnitTest lintDebug assembleDebug assembleRelease --stacktrace`
- verified all generated APK metadata reports versionCode 13 and versionName 1.5.0
- installed the clean arm64 debug APK on Android 16 and verified Settings displays Version 1.5.0

The v1.5.0 tag will be created only after this PR and its required CI pass.