### PR TITLE
Sync F-Droid metadata for Voyager 1.5.0

### DIFF
--- a/metadata/com.voyagerfiles.yml
+++ b/metadata/com.voyagerfiles.yml
@@ -11,8 +11,7 @@ AutoName: Voyager
 
 RepoType: git
 Repo: https://github.com/AlanHuang99/Voyager.git
-Binaries: 
-  https://github.com/AlanHuang99/Voyager/releases/download/v%v/voyager-v%v-universal.apk
+Binaries: https://github.com/AlanHuang99/Voyager/releases/download/v%v/voyager-v%v-universal.apk
 
 Builds:
   - versionName: 1.1.1
@@ -78,9 +77,18 @@ Builds:
     gradleprops:
       - voyager.enableAbiSplits=false
 
+  - versionName: 1.5.0
+    versionCode: 13
+    commit: b935d9cfa8d6252cc91bbee7cb7caf81efb5cc3d
+    subdir: app
+    gradle:
+      - yes
+    gradleprops:
+      - voyager.enableAbiSplits=false
+
 AllowedAPKSigningKeys: db496277d456751abe8ca6405026337c81a561a134e38d49c8e21fb8f036badf
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
-CurrentVersion: 1.4.0
-CurrentVersionCode: 12
+CurrentVersion: 1.5.0
+CurrentVersionCode: 13


### PR DESCRIPTION
## Summary

- add the Voyager 1.5.0/versionCode 13 F-Droid build entry
- pin the build to release application commit `b935d9cfa8d6252cc91bbee7cb7caf81efb5cc3d`
- update CurrentVersion fields and normalize the Binaries value

## Validation

- parsed the metadata with PyYAML and asserted the 1.5.0 fields and full source commit
- verified the pinned commit contains versionCode 13 and versionName 1.5.0
- `fdroid rewritemeta -l com.voyagerfiles` reports no formatting rewrite
- `git diff --check`

The v1.5.0 tag will target the same pinned application commit after this metadata sync merges.