### PR TITLE
Sync F-Droid metadata for Voyager 1.6.0

### DIFF
--- a/metadata/com.voyagerfiles.yml
+++ b/metadata/com.voyagerfiles.yml
@@ -86,9 +86,18 @@ Builds:
     gradleprops:
       - voyager.enableAbiSplits=false
 
+  - versionName: 1.6.0
+    versionCode: 14
+    commit: c91c4ea3a6192af8ee62580ed079d4282336ada4
+    subdir: app
+    gradle:
+      - yes
+    gradleprops:
+      - voyager.enableAbiSplits=false
+
 AllowedAPKSigningKeys: db496277d456751abe8ca6405026337c81a561a134e38d49c8e21fb8f036badf
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
-CurrentVersion: 1.5.0
-CurrentVersionCode: 13
+CurrentVersion: 1.6.0
+CurrentVersionCode: 14


### PR DESCRIPTION
## Summary

- add the Voyager 1.6.0 build recipe with version code 14
- pin the recipe to release commit `c91c4ea3a6192af8ee62580ed079d4282336ada4`
- update `CurrentVersion` and `CurrentVersionCode`

## Verification

- `fdroid readmeta` and `fdroid lint com.voyagerfiles` passed in an isolated fdroiddata-compatible layout with current official category keys
- `./gradlew --no-daemon --max-workers=2 -Pvoyager.enableAbiSplits=false clean assembleRelease --stacktrace`
- the recipe configuration produced exactly one universal APK with package `com.voyagerfiles`, version code 14, and version name 1.6.0
- the public v1.6.0 release APKs pass their SHA-256 manifest, use the expected signing certificate, and match the declared package metadata