### PR TITLE
Fix Android file opening and archive interactions

### DIFF
--- a/app/src/androidTest/java/com/voyagerfiles/ui/components/FileDetailsSheetTest.kt
+++ b/app/src/androidTest/java/com/voyagerfiles/ui/components/FileDetailsSheetTest.kt
@@ -1,9 +1,12 @@
 package com.voyagerfiles.ui.components
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasScrollToIndexAction
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performScrollToNode
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.voyagerfiles.data.model.FileItem
 import com.voyagerfiles.ui.theme.VoyagerTheme
@@ -39,6 +42,7 @@ class FileDetailsSheetTest {
         composeTestRule.onNodeWithText("report.pdf").assertIsDisplayed()
         composeTestRule.onNodeWithText("2 KB").assertIsDisplayed()
         composeTestRule.onNodeWithText("/storage/emulated/0/Documents/report.pdf").assertIsDisplayed()
+        composeTestRule.onNode(hasScrollToIndexAction()).performScrollToNode(hasText("media_rw"))
         composeTestRule.onNodeWithText("media_rw").assertIsDisplayed()
         composeTestRule.onNodeWithText("rw-r--r--").performScrollTo().assertIsDisplayed()
     }

--- a/app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserSelectionActionsTest.kt
+++ b/app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserSelectionActionsTest.kt
@@ -10,14 +10,19 @@ import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTouchInput
 import androidx.test.core.app.ApplicationProvider
 import com.voyagerfiles.data.local.PreferencesManager
 import com.voyagerfiles.data.model.ViewMode
 import com.voyagerfiles.viewmodel.FileBrowserViewModel
 import java.io.File
+import java.io.FileOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 import kotlinx.coroutines.runBlocking
 import org.junit.After
+import org.junit.Assert.assertFalse
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -36,7 +41,11 @@ class BrowserSelectionActionsTest {
             deleteRecursively()
             mkdirs()
             resolve("notes.txt").writeText("notes")
-            resolve("archive.zip").writeBytes(byteArrayOf())
+            ZipOutputStream(FileOutputStream(resolve("archive.zip"))).use { zip ->
+                zip.putNextEntry(ZipEntry("inside.txt"))
+                zip.write("inside".toByteArray())
+                zip.closeEntry()
+            }
             resolve("legacy.rar").writeBytes(byteArrayOf())
             resolve("Folder").mkdirs()
         }
@@ -131,7 +140,9 @@ class BrowserSelectionActionsTest {
         composeTestRule.onNodeWithText("Details").assertIsDisplayed().performClick()
 
         composeTestRule.onNodeWithText("Details").assertIsDisplayed()
-        composeTestRule.onNodeWithText(root.resolve("notes.txt").absolutePath).assertIsDisplayed()
+        composeTestRule.onNodeWithText(root.resolve("notes.txt").absolutePath)
+            .performScrollTo()
+            .assertIsDisplayed()
     }
 
     @Test
@@ -182,6 +193,37 @@ class BrowserSelectionActionsTest {
         composeTestRule.onNodeWithContentDescription("More selection actions").performClick()
 
         composeTestRule.onNodeWithText("Extract here").assertIsDisplayed()
+    }
+
+    @Test
+    fun tappingSupportedArchiveConfirmsBeforeExtraction() {
+        val viewModel = launchBrowser()
+        waitForRoot(viewModel)
+
+        composeTestRule.onNode(hasText("archive.zip") and hasClickAction()).performClick()
+
+        composeTestRule.onNodeWithText("Extract archive?").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Cancel").assertIsDisplayed().performClick()
+        composeTestRule.onNodeWithText("Extract archive?").assertDoesNotExist()
+        assertFalse(root.resolve("archive_extracted").exists())
+
+        composeTestRule.onNode(hasText("archive.zip") and hasClickAction()).performClick()
+        composeTestRule.onNodeWithText("Extract").assertIsDisplayed().performClick()
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            root.resolve("archive_extracted/inside.txt").isFile
+        }
+    }
+
+    @Test
+    fun tappingUnsupportedArchiveExplainsWhyWithoutConfirming() {
+        val viewModel = launchBrowser()
+        waitForRoot(viewModel)
+
+        composeTestRule.onNode(hasText("legacy.rar") and hasClickAction()).performClick()
+
+        composeTestRule.onNodeWithText("RAR extraction is not available in this build")
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText("Extract archive?").assertDoesNotExist()
     }
 
     @Test

--- a/app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserSelectionActionsTest.kt
+++ b/app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserSelectionActionsTest.kt
@@ -135,6 +135,30 @@ class BrowserSelectionActionsTest {
     }
 
     @Test
+    fun oneLocalFileOffersOpenWith() {
+        val viewModel = launchBrowser()
+        waitForRoot(viewModel)
+
+        composeTestRule.onNode(hasText("notes.txt") and hasClickAction())
+            .performTouchInput { longClick() }
+        composeTestRule.onNodeWithContentDescription("More selection actions").performClick()
+
+        composeTestRule.onNodeWithText("Open with").assertIsDisplayed()
+    }
+
+    @Test
+    fun aFolderDoesNotOfferOpenWith() {
+        val viewModel = launchBrowser()
+        waitForRoot(viewModel)
+
+        composeTestRule.onNode(hasText("Folder") and hasClickAction())
+            .performTouchInput { longClick() }
+        composeTestRule.onNodeWithContentDescription("More selection actions").performClick()
+
+        composeTestRule.onNodeWithText("Open with").assertDoesNotExist()
+    }
+
+    @Test
     fun selectedFileCanOpenCompressionDialogWithSafeDefaultName() {
         val viewModel = launchBrowser()
         waitForRoot(viewModel)

--- a/app/src/androidTest/java/com/voyagerfiles/ui/screens/SessionAutoCloseNavigationTest.kt
+++ b/app/src/androidTest/java/com/voyagerfiles/ui/screens/SessionAutoCloseNavigationTest.kt
@@ -3,10 +3,13 @@ package com.voyagerfiles.ui.screens
 import android.app.Application
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasScrollToIndexAction
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
 import androidx.test.core.app.ApplicationProvider
 import com.voyagerfiles.data.local.PreferencesManager
 import com.voyagerfiles.data.model.SessionAutoCloseTimeout
@@ -75,6 +78,7 @@ class SessionAutoCloseNavigationTest {
         composeTestRule.waitUntil(timeoutMillis = 10_000) {
             viewModel.sessions.value.size == 1 && !viewModel.browseState.value.isLoading
         }
+        composeTestRule.onNode(hasScrollToIndexAction()).performScrollToNode(hasText(root.name))
         composeTestRule.onNodeWithText(root.name).assertIsDisplayed().performClick()
         composeTestRule.onNodeWithContentDescription("Back").assertIsDisplayed()
         val previousGeneration = viewModel.sessionClosureGeneration.value
@@ -112,6 +116,7 @@ class SessionAutoCloseNavigationTest {
         composeTestRule.waitUntil(timeoutMillis = 10_000) {
             viewModel.sessions.value.size == 1 && !viewModel.browseState.value.isLoading
         }
+        composeTestRule.onNode(hasScrollToIndexAction()).performScrollToNode(hasText(root.name))
         composeTestRule.onNodeWithText(root.name).assertIsDisplayed().performClick()
         composeTestRule.onNodeWithContentDescription("Back").assertIsDisplayed()
         val previousGeneration = viewModel.sessionClosureGeneration.value

--- a/app/src/androidTest/java/com/voyagerfiles/util/FileSharingTest.kt
+++ b/app/src/androidTest/java/com/voyagerfiles/util/FileSharingTest.kt
@@ -1,7 +1,9 @@
 package com.voyagerfiles.util
 
+import android.Manifest
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -77,6 +79,16 @@ class FileSharingTest {
         assertEquals(uri, intent.data)
         assertEquals("application/pdf", intent.type)
         assertTrue(intent.flags and Intent.FLAG_GRANT_READ_URI_PERMISSION != 0)
+    }
+
+    @Test
+    fun appCanRequestTheSystemPackageInstallerForApkFiles() {
+        val requestedPermissions = context.packageManager
+            .getPackageInfo(context.packageName, PackageManager.GET_PERMISSIONS)
+            .requestedPermissions
+            .orEmpty()
+
+        assertTrue(Manifest.permission.REQUEST_INSTALL_PACKAGES in requestedPermissions)
     }
 
     private fun createLocalFile(name: String): FileItem {

--- a/app/src/androidTest/java/com/voyagerfiles/util/FileSharingTest.kt
+++ b/app/src/androidTest/java/com/voyagerfiles/util/FileSharingTest.kt
@@ -82,6 +82,19 @@ class FileSharingTest {
     }
 
     @Test
+    fun openWithWrapsTheReadableViewIntentInAChooser() {
+        val file = createLocalFile("report.pdf")
+
+        val chooser = FileUtils.createOpenWithIntent(context, file).getOrThrow()
+        val target = chooser.getParcelableExtra(Intent.EXTRA_INTENT, Intent::class.java)
+
+        assertEquals(Intent.ACTION_CHOOSER, chooser.action)
+        assertEquals(Intent.ACTION_VIEW, target?.action)
+        assertEquals("application/pdf", target?.type)
+        assertTrue(target!!.flags and Intent.FLAG_GRANT_READ_URI_PERMISSION != 0)
+    }
+
+    @Test
     fun appCanRequestTheSystemPackageInstallerForApkFiles() {
         val requestedPermissions = context.packageManager
             .getPackageInfo(context.packageName, PackageManager.GET_PERMISSIONS)

--- a/app/src/androidTest/java/com/voyagerfiles/viewmodel/ArchiveOperationsTest.kt
+++ b/app/src/androidTest/java/com/voyagerfiles/viewmodel/ArchiveOperationsTest.kt
@@ -4,6 +4,9 @@ import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import java.io.File
+import java.io.FileOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
@@ -74,6 +77,39 @@ class ArchiveOperationsTest {
             "on-device archive content",
             root.resolve("bundle_extracted/notes.txt").readText(),
         )
+    }
+
+    @Test
+    fun extractsArchiveByPathWithoutSelection() = runBlocking {
+        val archive = root.resolve("bundle.zip")
+        ZipOutputStream(FileOutputStream(archive)).use { zip ->
+            zip.putNextEntry(ZipEntry("inside.txt"))
+            zip.write("direct extraction content".toByteArray())
+            zip.closeEntry()
+        }
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        val viewModel = withContext(Dispatchers.Main) {
+            FileBrowserViewModel(application).also { it.openLocalRoot(root.absolutePath) }
+        }
+        waitUntil("open test root", viewModel) {
+            viewModel.browseState.value.currentPath == root.absolutePath &&
+                viewModel.browseState.value.files.any { it.path == archive.absolutePath } &&
+                !viewModel.browseState.value.isLoading
+        }
+
+        withContext(Dispatchers.Main) {
+            viewModel.extractArchive(archive.absolutePath)
+        }
+        waitUntil("extract bundle.zip directly", viewModel) {
+            viewModel.operationState.value == OperationState.Idle &&
+                root.resolve("bundle_extracted/inside.txt").isFile
+        }
+
+        assertEquals(
+            "direct extraction content",
+            root.resolve("bundle_extracted/inside.txt").readText(),
+        )
+        assertTrue(viewModel.browseState.value.selectedFiles.isEmpty())
     }
 
     private suspend fun waitUntil(

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
         tools:ignore="ScopedStorage" />
 
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <!-- Network access for remote protocols -->
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/app/src/main/java/com/voyagerfiles/ui/screens/BrowserArchiveActions.kt
+++ b/app/src/main/java/com/voyagerfiles/ui/screens/BrowserArchiveActions.kt
@@ -11,7 +11,20 @@ enum class BrowserArchiveAction {
     EXTRACTION_UNSUPPORTED,
 }
 
+enum class ArchiveTapAction {
+    CONFIRM_EXTRACTION,
+    SHOW_UNSUPPORTED,
+    OPEN_EXTERNALLY,
+}
+
 object BrowserArchiveActions {
+
+    fun tapAction(item: FileItem): ArchiveTapAction = when {
+        ArchiveFormat.detect(item.name)?.canExtract == true ->
+            ArchiveTapAction.CONFIRM_EXTRACTION
+        item.isArchive -> ArchiveTapAction.SHOW_UNSUPPORTED
+        else -> ArchiveTapAction.OPEN_EXTERNALLY
+    }
 
     fun forSelection(items: List<FileItem>): Set<BrowserArchiveAction> = buildSet {
         if (items.isEmpty()) return@buildSet

--- a/app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt
+++ b/app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.SelectAll
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.ViewAgenda
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
@@ -158,6 +159,7 @@ fun BrowserScreen(
     var showCreateMenu by remember { mutableStateOf(false) }
     var showSessionsSheet by remember { mutableStateOf(false) }
     var archiveNameDialogDefault by remember { mutableStateOf<String?>(null) }
+    var archiveToExtract by remember { mutableStateOf<FileItem?>(null) }
 
     val isSelectionMode = state.selectedFiles.isNotEmpty()
     val isNetwork = state.source.isNetwork
@@ -238,6 +240,33 @@ fun BrowserScreen(
                 }
             },
         )
+    }
+
+    fun handleDeviceFileTap(file: FileItem) {
+        when (BrowserArchiveActions.tapAction(file)) {
+            ArchiveTapAction.CONFIRM_EXTRACTION -> archiveToExtract = file
+            ArchiveTapAction.SHOW_UNSUPPORTED -> {
+                scope.launch {
+                    snackbarHostState.showSnackbar(
+                        BrowserArchiveActions.unsupportedExtractionReason(listOf(file))
+                            ?: "This archive type cannot be extracted"
+                    )
+                }
+            }
+            ArchiveTapAction.OPEN_EXTERNALLY -> {
+                FileUtils.openFile(context, file).onFailure { error ->
+                    scope.launch {
+                        snackbarHostState.showSnackbar(
+                            if (error is ActivityNotFoundException) {
+                                "No app can open this file type"
+                            } else {
+                                "Could not open this file"
+                            }
+                        )
+                    }
+                }
+            }
+        }
     }
 
     // Show snackbar messages from ViewModel
@@ -780,17 +809,7 @@ fun BrowserScreen(
                                     } else if (isNetwork) {
                                         viewModel.downloadFile(file.path)
                                     } else if (state.source == FileSource.LOCAL || state.source == FileSource.SAF) {
-                                        FileUtils.openFile(context, file).onFailure { error ->
-                                            scope.launch {
-                                                snackbarHostState.showSnackbar(
-                                                    if (error is ActivityNotFoundException) {
-                                                        "No app can open this file type"
-                                                    } else {
-                                                        "Could not open this file"
-                                                    }
-                                                )
-                                            }
-                                        }
+                                        handleDeviceFileTap(file)
                                     }
                                 },
                                 onLongClick = {
@@ -822,17 +841,7 @@ fun BrowserScreen(
                                     } else if (isNetwork) {
                                         viewModel.downloadFile(file.path)
                                     } else if (state.source == FileSource.LOCAL || state.source == FileSource.SAF) {
-                                        FileUtils.openFile(context, file).onFailure { error ->
-                                            scope.launch {
-                                                snackbarHostState.showSnackbar(
-                                                    if (error is ActivityNotFoundException) {
-                                                        "No app can open this file type"
-                                                    } else {
-                                                        "Could not open this file"
-                                                    }
-                                                )
-                                            }
-                                        }
+                                        handleDeviceFileTap(file)
                                     }
                                 },
                                 onLongClick = {
@@ -896,6 +905,31 @@ fun BrowserScreen(
             onCreate = { name ->
                 viewModel.createZipFromSelection(name)
                 archiveNameDialogDefault = null
+            },
+        )
+    }
+
+    archiveToExtract?.let { archive ->
+        AlertDialog(
+            onDismissRequest = { archiveToExtract = null },
+            title = { Text("Extract archive?") },
+            text = {
+                Text("Extract ${archive.name} into a new folder in this location?")
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        viewModel.extractArchive(archive.path)
+                        archiveToExtract = null
+                    },
+                ) {
+                    Text("Extract")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { archiveToExtract = null }) {
+                    Text("Cancel")
+                }
             },
         )
     }

--- a/app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt
+++ b/app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.automirrored.filled.Sort
 import androidx.compose.material.icons.automirrored.filled.ViewList
 import androidx.compose.material.icons.filled.Archive
@@ -167,13 +168,20 @@ fun BrowserScreen(
         BrowserArchiveActions.forSelection(selectedItems)
     }
     val sharePlan = remember(selectedItems) { ShareIntentPlan.forFiles(selectedItems) }
+    val canOpenWith = remember(selectedItems) {
+        selectedItems.singleOrNull()?.let { item ->
+            !item.isDirectory &&
+                (item.source == FileSource.LOCAL || item.source == FileSource.SAF)
+        } == true
+    }
     val toolbarModel = remember(isNetwork) { BrowserToolbarModel.forState(isNetwork) }
     val createMenuModel = remember(isNetwork) { BrowserCreateMenuModel.forState(isNetwork) }
-    val selectionToolbarModel = remember(isNetwork, selectedItems.size, sharePlan) {
+    val selectionToolbarModel = remember(isNetwork, selectedItems.size, sharePlan, canOpenWith) {
         SelectionToolbarModel.forState(
             isRemote = isNetwork,
             selectionCount = selectedItems.size,
             canShare = sharePlan != null,
+            canOpenWith = canOpenWith,
         )
     }
     val runningOperation = operationState as? OperationState.Running
@@ -208,6 +216,24 @@ fun BrowserScreen(
                 scope.launch {
                     snackbarHostState.showSnackbar(
                         "Could not share the selected files. Check that access is still available and try again."
+                    )
+                }
+            },
+        )
+    }
+
+    fun openSelectedWith() {
+        val file = selectedItems.singleOrNull() ?: return
+        FileUtils.openFileWith(context, file).fold(
+            onSuccess = { viewModel.clearSelection() },
+            onFailure = { error ->
+                scope.launch {
+                    snackbarHostState.showSnackbar(
+                        if (error is ActivityNotFoundException) {
+                            "No app can open this file type"
+                        } else {
+                            "Could not open this file"
+                        }
                     )
                 }
             },
@@ -395,6 +421,16 @@ fun BrowserScreen(
                                         onClick = {
                                             showDetailsFor = selectedItems.singleOrNull()
                                             showSelectionMoreMenu = false
+                                        },
+                                    )
+                                }
+                                if (SelectionToolbarAction.OPEN_WITH in selectionToolbarModel.overflowActions) {
+                                    DropdownMenuItem(
+                                        text = { Text("Open with") },
+                                        leadingIcon = { Icon(Icons.AutoMirrored.Filled.OpenInNew, null) },
+                                        onClick = {
+                                            showSelectionMoreMenu = false
+                                            openSelectedWith()
                                         },
                                     )
                                 }
@@ -1075,6 +1111,7 @@ data class SelectionToolbarModel(
             isRemote: Boolean,
             selectionCount: Int,
             canShare: Boolean,
+            canOpenWith: Boolean = false,
         ): SelectionToolbarModel {
             val isSingle = selectionCount == 1
             val primaryActions = when {
@@ -1108,6 +1145,7 @@ data class SelectionToolbarModel(
                     add(SelectionToolbarAction.SELECT_ALL)
                     if (isRemote) add(SelectionToolbarAction.DOWNLOAD)
                     if (isSingle) add(SelectionToolbarAction.DETAILS)
+                    if (canOpenWith) add(SelectionToolbarAction.OPEN_WITH)
                 },
             )
         }
@@ -1123,6 +1161,7 @@ enum class SelectionToolbarAction {
     RENAME,
     SHARE,
     DETAILS,
+    OPEN_WITH,
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/com/voyagerfiles/util/FileUtils.kt
+++ b/app/src/main/java/com/voyagerfiles/util/FileUtils.kt
@@ -142,6 +142,17 @@ object FileUtils {
             context.startActivity(intent)
         }
 
+    fun createOpenWithIntent(context: Context, file: FileItem): Result<Intent> =
+        createOpenFileIntent(context, file).map { target ->
+            Intent.createChooser(target, "Open with")
+        }
+
+    fun openFileWith(context: Context, file: FileItem): Result<Unit> =
+        createOpenWithIntent(context, file).mapCatching { chooser ->
+            if (context !is Activity) chooser.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            context.startActivity(chooser)
+        }
+
     fun shareFile(context: Context, file: FileItem) {
         shareFiles(context, listOf(file)).getOrThrow()
     }

--- a/app/src/main/java/com/voyagerfiles/viewmodel/FileBrowserViewModel.kt
+++ b/app/src/main/java/com/voyagerfiles/viewmodel/FileBrowserViewModel.kt
@@ -534,8 +534,33 @@ class FileBrowserViewModel(application: Application) : AndroidViewModel(applicat
             showSnackbar("The selected archive is no longer available. Refresh the folder and try again.")
             return
         }
+        launchArchiveExtraction(
+            archive = archive,
+            destinationDirectory = state.currentPath,
+            clearSelectionAfter = true,
+        )
+    }
+
+    fun extractArchive(path: String) {
+        val state = _browseState.value
+        val archive = state.files.firstOrNull { it.path == path }
+        if (archive == null) {
+            showSnackbar("The archive is no longer available. Refresh the folder and try again.")
+            return
+        }
+        launchArchiveExtraction(
+            archive = archive,
+            destinationDirectory = state.currentPath,
+            clearSelectionAfter = false,
+        )
+    }
+
+    private fun launchArchiveExtraction(
+        archive: FileItem,
+        destinationDirectory: String,
+        clearSelectionAfter: Boolean,
+    ) {
         val provider = fileProvider
-        val destinationDirectory = state.currentPath
         val publishProgress = archiveProgressPublisher("Extracting")
 
         launchOperation("Extracting") {
@@ -546,7 +571,7 @@ class FileBrowserViewModel(application: Application) : AndroidViewModel(applicat
                 onProgress = publishProgress,
             ).fold(
                 onSuccess = { extractionRoot ->
-                    clearSelection()
+                    if (clearSelectionAfter) clearSelection()
                     refreshFiles()
                     showSnackbar("Extracted to ${extractionRoot.name}")
                 },

--- a/app/src/test/java/com/voyagerfiles/ui/screens/BrowserArchiveActionsTest.kt
+++ b/app/src/test/java/com/voyagerfiles/ui/screens/BrowserArchiveActionsTest.kt
@@ -93,6 +93,26 @@ class BrowserArchiveActionsTest {
         )
     }
 
+    @Test
+    fun supportedArchiveTapRequestsConfirmation() {
+        assertEquals(
+            ArchiveTapAction.CONFIRM_EXTRACTION,
+            BrowserArchiveActions.tapAction(file("bundle.zip")),
+        )
+    }
+
+    @Test
+    fun unsupportedAndOrdinaryFilesKeepDistinctTapBehavior() {
+        assertEquals(
+            ArchiveTapAction.SHOW_UNSUPPORTED,
+            BrowserArchiveActions.tapAction(file("legacy.rar")),
+        )
+        assertEquals(
+            ArchiveTapAction.OPEN_EXTERNALLY,
+            BrowserArchiveActions.tapAction(file("notes.txt")),
+        )
+    }
+
     private fun file(name: String, isDirectory: Boolean = false): FileItem =
         FileItem(name = name, path = "/$name", isDirectory = isDirectory)
 }

--- a/app/src/test/java/com/voyagerfiles/ui/screens/BrowserToolbarModelTest.kt
+++ b/app/src/test/java/com/voyagerfiles/ui/screens/BrowserToolbarModelTest.kt
@@ -96,4 +96,44 @@ class BrowserToolbarModelTest {
         assertFalse(model.overflowActions.contains(SelectionToolbarAction.RENAME))
         assertTrue(model.overflowActions.contains(SelectionToolbarAction.DOWNLOAD))
     }
+
+    @Test
+    fun oneLocalFileOffersOpenWithInOverflow() {
+        val model = SelectionToolbarModel.forState(
+            isRemote = false,
+            selectionCount = 1,
+            canShare = true,
+            canOpenWith = true,
+        )
+
+        assertTrue(SelectionToolbarAction.OPEN_WITH in model.overflowActions)
+    }
+
+    @Test
+    fun foldersRemoteItemsAndMultipleSelectionsDoNotOfferOpenWith() {
+        assertFalse(
+            SelectionToolbarAction.OPEN_WITH in SelectionToolbarModel.forState(
+                isRemote = false,
+                selectionCount = 1,
+                canShare = false,
+                canOpenWith = false,
+            ).overflowActions,
+        )
+        assertFalse(
+            SelectionToolbarAction.OPEN_WITH in SelectionToolbarModel.forState(
+                isRemote = true,
+                selectionCount = 1,
+                canShare = false,
+                canOpenWith = false,
+            ).overflowActions,
+        )
+        assertFalse(
+            SelectionToolbarAction.OPEN_WITH in SelectionToolbarModel.forState(
+                isRemote = false,
+                selectionCount = 2,
+                canShare = true,
+                canOpenWith = false,
+            ).overflowActions,
+        )
+    }
 }

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -29,11 +29,12 @@ Reports are written under `app/build/reports/`. APKs are written under `app/buil
 Connect an Android device through USB or wireless debugging and confirm that `adb devices` reports it as `device` rather than `offline` or `unauthorized`.
 
 ```bash
-adb connect 192.168.27.167:5555
-ANDROID_SERIAL=192.168.27.167:5555 ./gradlew connectedDebugAndroidTest --stacktrace
+adb mdns services
+adb connect DEVICE_ADDRESS:WIRELESS_DEBUGGING_PORT
+ANDROID_SERIAL=DEVICE_ADDRESS:WIRELESS_DEBUGGING_PORT ./gradlew connectedDebugAndroidTest --stacktrace
 ```
 
-Instrumentation installs the debug package `com.voyagerfiles.debug`. The current tests exercise Android file-open intents, generated SFTP public-key export, image and first-page PDF thumbnails, determinate and indeterminate operation progress, archive naming and a ZIP create/extract round trip, unavailable-storage presentation, saved-connection and file-delete confirmations, single and multiple share intents, contextual selection actions, permanent local deletion, compact-view persistence, file details, parent navigation after using search, selection-control accessibility labels, and Android Keystore encryption.
+Instrumentation installs the debug package `com.voyagerfiles.debug`. The current tests exercise direct Android file-open intents, the explicit Open with chooser, APK installer permission, generated SFTP public-key export, image and first-page PDF thumbnails, determinate and indeterminate operation progress, archive naming, direct and selection-based ZIP extraction, archive-tap confirmation and cancellation, unavailable-storage presentation, saved-connection and file-delete confirmations, single and multiple share intents, contextual selection actions, permanent local deletion, compact-view persistence, file details, parent navigation after using search, selection-control accessibility labels, and Android Keystore encryption.
 
 Run the issue-focused device coverage with:
 
@@ -77,9 +78,9 @@ Use disposable files and keep device orientation unlocked unless a case calls fo
 | Storage | Browse internal storage, an available removable volume, and an unavailable or unmounted volume if one is present. |
 | Navigation | Enter nested directories, use breadcrumbs and Back, switch sessions during a slow load, rotate the device, and confirm the latest location remains visible. |
 | Search and filters | Search case-insensitively, combine search with each type filter, select all visible results, clear filters, and test an empty result. |
-| File opening and thumbnails | Open a local or SAF file, choose an Android handler as the default where the OS offers that choice, reopen the file, and confirm the default is honored; verify image and first-page PDF thumbnails in list and grid layouts, including an invalid PDF fallback. |
+| File opening and thumbnails | Open a local or SAF file, choose an Android handler as the default where the OS offers that choice, reopen the file, and confirm the default is honored; use Open with on one selected file and confirm the chooser appears; open an APK, allow Voyager as an installation source if prompted, confirm the system package installer opens, then cancel installation; verify image and first-page PDF thumbnails in list and grid layouts, including an invalid PDF fallback. |
 | File operations | Create, rename, copy, move, and delete files and directories; share one and several local or SAF files; inspect Details; attempt a duplicate destination and a move into a descendant; verify the source survives failures; verify determinate progress for known sizes and indeterminate progress for unknown totals. |
-| Archives | Create ZIP files from one file, several items, an empty directory, and a nested directory; extract ZIP, TAR, TGZ/TAR.GZ, TBZ2/TAR.BZ2, GZ, and BZ2 fixtures; repeat on a SAF or disposable remote provider; verify conflicts do not overwrite data; verify corrupt, encrypted, traversal, link, and RAR inputs fail with an actionable message and leave no partial extraction root. |
+| Archives | Create ZIP files from one file, several items, an empty directory, and a nested directory; tap a supported archive and verify Cancel leaves the folder unchanged while Extract creates a new extraction root; extract ZIP, TAR, TGZ/TAR.GZ, TBZ2/TAR.BZ2, GZ, and BZ2 fixtures; repeat on a SAF or disposable remote provider; verify conflicts do not overwrite data; verify corrupt, encrypted, traversal, link, and RAR inputs fail with an actionable message and leave no partial extraction root. |
 | Trash | For a direct-local selection, verify both Trash and permanent choices; move a file to Trash, restore it, create a restore conflict, permanently delete an entry, empty Trash, and repeat with Trash disabled. |
 | Error recovery | Remove or unmount a location while browsing, deny a SAF operation, open an unsupported file, use a bad remote hostname, and verify retry or actionable feedback. |
 | Remote | Generate an SFTP key, copy and save its public key, authenticate with it while leaving the password blank, verify first-use pinning and changed-key rejection, verify FTP cleartext confirmation, HTTPS WebDAV on a custom port, HTTP warning, large transfers, and a connection delete confirmation. |
@@ -90,20 +91,20 @@ Use disposable files and keep device orientation unlocked unless a case calls fo
 Install the universal debug APK without clearing app data:
 
 ```bash
-adb -s 192.168.27.167:5555 install -r app/build/outputs/apk/debug/app-universal-debug.apk
+adb -s DEVICE_ADDRESS:WIRELESS_DEBUGGING_PORT install -r app/build/outputs/apk/debug/app-universal-debug.apk
 ```
 
 Open Android's app-specific all-files access page through Voyager's own permission flow. For a dedicated test device only, the equivalent app-op can be controlled directly:
 
 ```bash
-adb -s 192.168.27.167:5555 shell appops set com.voyagerfiles.debug MANAGE_EXTERNAL_STORAGE allow
-adb -s 192.168.27.167:5555 shell appops set com.voyagerfiles.debug MANAGE_EXTERNAL_STORAGE deny
+adb -s DEVICE_ADDRESS:WIRELESS_DEBUGGING_PORT shell appops set com.voyagerfiles.debug MANAGE_EXTERNAL_STORAGE allow
+adb -s DEVICE_ADDRESS:WIRELESS_DEBUGGING_PORT shell appops set com.voyagerfiles.debug MANAGE_EXTERNAL_STORAGE deny
 ```
 
 Capture a screenshot and UI hierarchy for a visual or accessibility review:
 
 ```bash
-adb -s 192.168.27.167:5555 exec-out screencap -p > /tmp/voyager.png
-adb -s 192.168.27.167:5555 shell uiautomator dump /sdcard/window.xml
-adb -s 192.168.27.167:5555 pull /sdcard/window.xml /tmp/voyager-window.xml
+adb -s DEVICE_ADDRESS:WIRELESS_DEBUGGING_PORT exec-out screencap -p > /tmp/voyager.png
+adb -s DEVICE_ADDRESS:WIRELESS_DEBUGGING_PORT shell uiautomator dump /sdcard/window.xml
+adb -s DEVICE_ADDRESS:WIRELESS_DEBUGGING_PORT pull /sdcard/window.xml /tmp/voyager-window.xml
 ```

--- a/docs/superpowers/plans/2026-08-06-file-interactions.md
+++ b/docs/superpowers/plans/2026-08-06-file-interactions.md
@@ -1,0 +1,342 @@
+# File Interactions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix APK opening, add an explicit Open with action, and make supported archive taps offer safe extraction.
+
+**Architecture:** Keep Android intent construction in `FileUtils`, selection eligibility in `SelectionToolbarModel`, and archive classification in `BrowserArchiveActions`. `BrowserScreen` owns transient chooser and confirmation UI state, while `FileBrowserViewModel` owns the extraction operation.
+
+**Tech Stack:** Kotlin 2.1, Android API 26–35, Jetpack Compose Material 3, AndroidX FileProvider, JUnit 4, AndroidX instrumentation.
+
+## Global Constraints
+
+- Preserve pull request #46 commit `fd80d15fa09bd0ea9ecce34d261e24f95d4284c2` with its original author.
+- Ordinary taps continue to honor Android defaults; only the explicit Open with action uses a chooser.
+- Only local and SAF files can be opened directly. Remote items must be downloaded first.
+- Supported archives require confirmation before extraction. Unsupported archives remain actionable errors.
+- Every production change follows red, green, refactor and receives K60 verification on Android 16/API 36.
+
+---
+
+### Task 1: APK installer permission
+
+**Files:**
+- Modify: `app/src/androidTest/java/com/voyagerfiles/util/FileSharingTest.kt`
+- Modify through preserved commit: `app/src/main/AndroidManifest.xml`
+
+**Interfaces:**
+- Consumes: installed debug package metadata from `PackageManager`.
+- Produces: a merged manifest containing `android.permission.REQUEST_INSTALL_PACKAGES`.
+
+- [ ] **Step 1: Write the failing device test**
+
+```kotlin
+@Test
+fun appCanRequestTheSystemPackageInstallerForApkFiles() {
+    val requested = context.packageManager
+        .getPackageInfo(context.packageName, PackageManager.GET_PERMISSIONS)
+        .requestedPermissions
+        .orEmpty()
+
+    assertTrue(Manifest.permission.REQUEST_INSTALL_PACKAGES in requested)
+}
+```
+
+- [ ] **Step 2: Run the test and verify the released manifest contract fails**
+
+Run: `ANDROID_SERIAL=192.168.27.182:37713 ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.voyagerfiles.util.FileSharingTest#appCanRequestTheSystemPackageInstallerForApkFiles --stacktrace`
+
+Expected: FAIL because the permission is absent.
+
+- [ ] **Step 3: Preserve the contributor fix**
+
+Run: `git fetch origin pull/46/head:refs/remotes/origin/pr-46 && git cherry-pick fd80d15fa09bd0ea9ecce34d261e24f95d4284c2`
+
+Expected manifest addition:
+
+```xml
+<uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+```
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run: `ANDROID_SERIAL=192.168.27.182:37713 ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.voyagerfiles.util.FileSharingTest#appCanRequestTheSystemPackageInstallerForApkFiles --stacktrace`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the regression test**
+
+```bash
+git add app/src/androidTest/java/com/voyagerfiles/util/FileSharingTest.kt
+git commit -m "test: cover APK installer permission"
+```
+
+### Task 2: Explicit Open with chooser
+
+**Files:**
+- Modify: `app/src/androidTest/java/com/voyagerfiles/util/FileSharingTest.kt`
+- Modify: `app/src/main/java/com/voyagerfiles/util/FileUtils.kt`
+
+**Interfaces:**
+- Consumes: `createOpenFileIntent(context: Context, file: FileItem): Result<Intent>`.
+- Produces: `createOpenWithIntent(context: Context, file: FileItem): Result<Intent>` and `openFileWith(context: Context, file: FileItem): Result<Unit>`.
+
+- [ ] **Step 1: Write the failing chooser-intent test**
+
+```kotlin
+@Test
+fun openWithWrapsTheReadableViewIntentInAChooser() {
+    val file = createLocalFile("report.pdf")
+
+    val chooser = FileUtils.createOpenWithIntent(context, file).getOrThrow()
+    val target = chooser.getParcelableExtra(Intent.EXTRA_INTENT, Intent::class.java)
+
+    assertEquals(Intent.ACTION_CHOOSER, chooser.action)
+    assertEquals(Intent.ACTION_VIEW, target?.action)
+    assertEquals("application/pdf", target?.type)
+    assertTrue(target!!.flags and Intent.FLAG_GRANT_READ_URI_PERMISSION != 0)
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run: `ANDROID_SERIAL=192.168.27.182:37713 ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.voyagerfiles.util.FileSharingTest#openWithWrapsTheReadableViewIntentInAChooser --stacktrace`
+
+Expected: compilation FAIL because `createOpenWithIntent` does not exist.
+
+- [ ] **Step 3: Implement chooser construction and launch**
+
+```kotlin
+fun createOpenWithIntent(context: Context, file: FileItem): Result<Intent> =
+    createOpenFileIntent(context, file).map { target ->
+        Intent.createChooser(target, "Open with")
+    }
+
+fun openFileWith(context: Context, file: FileItem): Result<Unit> =
+    createOpenWithIntent(context, file).mapCatching { chooser ->
+        if (context !is Activity) chooser.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        context.startActivity(chooser)
+    }
+```
+
+- [ ] **Step 4: Run all file-intent tests**
+
+Run: `ANDROID_SERIAL=192.168.27.182:37713 ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.voyagerfiles.util.FileSharingTest --stacktrace`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/voyagerfiles/util/FileUtils.kt app/src/androidTest/java/com/voyagerfiles/util/FileSharingTest.kt
+git commit -m "feat: add an explicit Open with chooser"
+```
+
+### Task 3: Open with selection eligibility
+
+**Files:**
+- Modify: `app/src/test/java/com/voyagerfiles/ui/screens/BrowserToolbarModelTest.kt`
+- Modify: `app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt`
+
+**Interfaces:**
+- Consumes: `SelectionToolbarModel.forState(isRemote, selectionCount, canShare, canOpenWith)`.
+- Produces: `SelectionToolbarAction.OPEN_WITH` in overflow only for one directly openable file.
+
+- [ ] **Step 1: Write failing model tests**
+
+```kotlin
+@Test
+fun oneLocalFileOffersOpenWithInOverflow() {
+    val model = SelectionToolbarModel.forState(
+        isRemote = false,
+        selectionCount = 1,
+        canShare = true,
+        canOpenWith = true,
+    )
+    assertTrue(SelectionToolbarAction.OPEN_WITH in model.overflowActions)
+}
+
+@Test
+fun foldersRemoteItemsAndMultipleSelectionsDoNotOfferOpenWith() {
+    assertFalse(SelectionToolbarAction.OPEN_WITH in SelectionToolbarModel.forState(false, 1, false, false).overflowActions)
+    assertFalse(SelectionToolbarAction.OPEN_WITH in SelectionToolbarModel.forState(true, 1, false, false).overflowActions)
+    assertFalse(SelectionToolbarAction.OPEN_WITH in SelectionToolbarModel.forState(false, 2, true, false).overflowActions)
+}
+```
+
+- [ ] **Step 2: Run the model tests and verify compilation fails**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.ui.screens.BrowserToolbarModelTest --stacktrace`
+
+Expected: compilation FAIL because `canOpenWith` and `OPEN_WITH` do not exist.
+
+- [ ] **Step 3: Implement eligibility and menu action**
+
+```kotlin
+val canOpenWith = selectedItems.singleOrNull()?.let { item ->
+    !item.isDirectory && (item.source == FileSource.LOCAL || item.source == FileSource.SAF)
+} == true
+```
+
+Add `OPEN_WITH` to `SelectionToolbarAction`, append it to overflow when `canOpenWith`, and launch `FileUtils.openFileWith(context, selectedItems.single())` from a new “Open with” menu item. Reuse the existing `ActivityNotFoundException` snackbar mapping and clear selection only after a successful launch.
+
+- [ ] **Step 4: Run the model and device selection tests**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.ui.screens.BrowserToolbarModelTest --stacktrace`
+
+Run: `ANDROID_SERIAL=192.168.27.182:37713 ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.voyagerfiles.ui.screens.BrowserSelectionActionsTest --stacktrace`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt app/src/test/java/com/voyagerfiles/ui/screens/BrowserToolbarModelTest.kt app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserSelectionActionsTest.kt
+git commit -m "feat: expose Open with for selected files"
+```
+
+### Task 4: Archive tap classification
+
+**Files:**
+- Modify: `app/src/test/java/com/voyagerfiles/ui/screens/BrowserArchiveActionsTest.kt`
+- Modify: `app/src/main/java/com/voyagerfiles/ui/screens/BrowserArchiveActions.kt`
+
+**Interfaces:**
+- Produces: `ArchiveTapAction` and `BrowserArchiveActions.tapAction(file: FileItem): ArchiveTapAction`.
+
+- [ ] **Step 1: Write failing classification tests**
+
+```kotlin
+@Test
+fun supportedArchiveTapRequestsConfirmation() {
+    assertEquals(ArchiveTapAction.CONFIRM_EXTRACTION, BrowserArchiveActions.tapAction(file("bundle.zip")))
+}
+
+@Test
+fun unsupportedAndOrdinaryFilesKeepDistinctTapBehavior() {
+    assertEquals(ArchiveTapAction.SHOW_UNSUPPORTED, BrowserArchiveActions.tapAction(file("legacy.rar")))
+    assertEquals(ArchiveTapAction.OPEN_EXTERNALLY, BrowserArchiveActions.tapAction(file("notes.txt")))
+}
+```
+
+- [ ] **Step 2: Run and verify compilation fails**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.ui.screens.BrowserArchiveActionsTest --stacktrace`
+
+Expected: compilation FAIL because `ArchiveTapAction` is missing.
+
+- [ ] **Step 3: Implement the classifier**
+
+```kotlin
+enum class ArchiveTapAction { CONFIRM_EXTRACTION, SHOW_UNSUPPORTED, OPEN_EXTERNALLY }
+
+fun tapAction(item: FileItem): ArchiveTapAction = when {
+    ArchiveFormat.detect(item.name)?.canExtract == true -> ArchiveTapAction.CONFIRM_EXTRACTION
+    item.isArchive -> ArchiveTapAction.SHOW_UNSUPPORTED
+    else -> ArchiveTapAction.OPEN_EXTERNALLY
+}
+```
+
+- [ ] **Step 4: Run the focused tests**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.ui.screens.BrowserArchiveActionsTest --stacktrace`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/voyagerfiles/ui/screens/BrowserArchiveActions.kt app/src/test/java/com/voyagerfiles/ui/screens/BrowserArchiveActionsTest.kt
+git commit -m "feat: classify archive tap behavior"
+```
+
+### Task 5: Confirm extraction from a direct tap
+
+**Files:**
+- Modify: `app/src/androidTest/java/com/voyagerfiles/viewmodel/ArchiveOperationsTest.kt`
+- Modify: `app/src/main/java/com/voyagerfiles/viewmodel/FileBrowserViewModel.kt`
+- Modify: `app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserSelectionActionsTest.kt`
+- Modify: `app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt`
+
+**Interfaces:**
+- Produces: `extractArchive(path: String)` and a Compose confirmation dialog bound to the selected `FileItem`.
+
+- [ ] **Step 1: Write a failing direct-extraction ViewModel test**
+
+Create `bundle.zip` in the active local directory, call `viewModel.extractArchive(archive.absolutePath)` without selecting it, wait for `OperationState.Idle`, and assert the exact extracted file contents under `bundle_extracted`.
+
+- [ ] **Step 2: Run and verify compilation fails**
+
+Run: `ANDROID_SERIAL=192.168.27.182:37713 ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.voyagerfiles.viewmodel.ArchiveOperationsTest --stacktrace`
+
+Expected: compilation FAIL because `extractArchive` does not exist.
+
+- [ ] **Step 3: Extract a shared archive operation**
+
+```kotlin
+fun extractArchive(path: String) {
+    val state = _browseState.value
+    val archive = state.files.firstOrNull { it.path == path }
+        ?: return showSnackbar("The archive is no longer available. Refresh the folder and try again.")
+    launchArchiveExtraction(archive, state.currentPath, clearSelectionAfter = false)
+}
+```
+
+Refactor `extractSelectedArchive()` to validate its single selection and call the same private `launchArchiveExtraction` helper with `clearSelectionAfter = true`.
+
+- [ ] **Step 4: Write the failing Compose confirmation test**
+
+Render `BrowserScreen` with a supported ZIP, click the ZIP row, assert an “Extract archive?” dialog and Cancel/Extract buttons, click Extract, and assert the ViewModel operation starts. Also assert an unsupported RAR reports the existing reason without showing the confirmation.
+
+- [ ] **Step 5: Implement confirmation UI in both list and grid paths**
+
+Store `archiveToExtract: FileItem?`, classify local/SAF file taps through `BrowserArchiveActions.tapAction`, and show `AlertDialog` whose confirmation calls `viewModel.extractArchive(item.path)`. Keep network taps mapped to download before archive classification.
+
+- [ ] **Step 6: Run archive unit and device tests**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.ui.screens.BrowserArchiveActionsTest --stacktrace`
+
+Run: `ANDROID_SERIAL=192.168.27.182:37713 ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.voyagerfiles.viewmodel.ArchiveOperationsTest,com.voyagerfiles.ui.screens.BrowserSelectionActionsTest --stacktrace`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/src/main/java/com/voyagerfiles/viewmodel/FileBrowserViewModel.kt app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt app/src/androidTest/java/com/voyagerfiles/viewmodel/ArchiveOperationsTest.kt app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserSelectionActionsTest.kt
+git commit -m "feat: confirm extraction when archives are opened"
+```
+
+### Task 6: Verification, documentation, and PR
+
+**Files:**
+- Modify: `docs/TESTING.md`
+
+- [ ] **Step 1: Document APK, Open with, and archive-tap device coverage**
+
+Update the file-opening and archive rows in the manual regression matrix and the focused instrumentation command.
+
+- [ ] **Step 2: Run the complete local gate**
+
+Run: `./gradlew testDebugUnitTest lintDebug assembleDebug assembleRelease --stacktrace`
+
+Expected: BUILD SUCCESSFUL with zero test or lint failures.
+
+- [ ] **Step 3: Run complete device instrumentation**
+
+Run: `ANDROID_SERIAL=192.168.27.182:37713 ./gradlew connectedDebugAndroidTest --stacktrace`
+
+Expected: BUILD SUCCESSFUL with zero failed tests.
+
+- [ ] **Step 4: Smoke-test on K60**
+
+Install `app/build/outputs/apk/debug/app-universal-debug.apk`, cleanly restart `com.voyagerfiles.debug`, tap a disposable APK and verify `com.android.packageinstaller` becomes foreground, cancel installation, use Open with on a PDF, and confirm/cancel ZIP extraction once each.
+
+- [ ] **Step 5: Commit docs, request review, push, and open PR**
+
+```bash
+git add docs/TESTING.md
+git commit -m "docs: cover file interaction regressions"
+git push -u origin codex/file-interactions
+gh pr create --base master --head codex/file-interactions --title "Fix Android file opening and archive interactions" --body "Closes #39\nCloses #42\nCloses #43"
+```

--- a/docs/superpowers/plans/2026-08-06-release-1.7.0.md
+++ b/docs/superpowers/plans/2026-08-06-release-1.7.0.md
@@ -1,0 +1,208 @@
+# Voyager 1.7.0 Release Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish the verified fixes for GitHub issues #39–#45 as Voyager 1.7.0 and align the reproducible F-Droid metadata.
+
+**Architecture:** A release pull request bumps Gradle and human-facing metadata, then its merge commit is tagged `v1.7.0`. GitHub Actions builds and signs public APKs, publishes checksums and Pages, and the published universal APK is verified before a follow-up metadata pull request pins F-Droid to the release commit.
+
+**Tech Stack:** Gradle Android plugin, GitHub Actions, GitHub CLI, `apksigner`, `aapt2`, F-Droid metadata.
+
+## Global Constraints
+
+- Release only after all three issue pull requests are merged and `master` CI is green.
+- Set `versionCode = 15` and `versionName = "1.7.0"`; tag exactly `v1.7.0`.
+- Never expose or commit signing secrets or keystores.
+- The published certificate SHA-256 must equal `db496277d456751abe8ca6405026337c81a561a134e38d49c8e21fb8f036badf`.
+- Release changelogs are named `15.txt`, stay below 500 characters, and describe only verified behavior.
+- The user gave explicit current-session permission to push the tag and publish the GitHub release.
+
+---
+
+### Task 1: Release version and changelog
+
+**Files:**
+- Modify: `app/build.gradle.kts`
+- Create: `fastlane/metadata/android/en-US/changelogs/15.txt`
+- Create: `metadata/en-US/changelogs/15.txt`
+- Modify: `README.md`
+- Modify: `fastlane/metadata/android/en-US/full_description.txt`
+
+**Interfaces:**
+- Produces: release version 1.7.0/code 15 and matching factual release text.
+
+- [ ] **Step 1: Create `codex/release-1.7.0` from current `origin/master`**
+
+Run: `git fetch origin && git switch master && git merge --ff-only origin/master && git switch -c codex/release-1.7.0`
+
+- [ ] **Step 2: Set version code and name**
+
+```kotlin
+versionCode = 15
+versionName = "1.7.0"
+```
+
+- [ ] **Step 3: Add matching changelogs**
+
+Use identical text in both `15.txt` files:
+
+```text
+Voyager 1.7.0:
+- Open APK files, choose an app with Open with, and confirm archive extraction
+- Improve selection haptics and dynamic-theme toolbar contrast
+- Fix writes into Storage Access Framework document trees
+- Show file names, bytes, percentage, and speed during uploads and downloads
+```
+
+- [ ] **Step 4: Refresh stable feature descriptions**
+
+Add Open with, archive creation/extraction, transfer detail, and generated SFTP key export to the existing concise feature lists. Inspect existing screenshots and replace them only if they materially misrepresent the browser UI.
+
+- [ ] **Step 5: Verify version and changelog consistency**
+
+Run: `rg -n 'versionCode|versionName|Voyager 1.7.0' app/build.gradle.kts fastlane/metadata/android/en-US/changelogs/15.txt metadata/en-US/changelogs/15.txt`
+
+Run: `wc -c fastlane/metadata/android/en-US/changelogs/15.txt metadata/en-US/changelogs/15.txt`
+
+Expected: version code 15, version name 1.7.0, identical changelogs, and each changelog below 500 bytes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/build.gradle.kts fastlane/metadata/android/en-US/changelogs/15.txt metadata/en-US/changelogs/15.txt README.md fastlane/metadata/android/en-US/full_description.txt
+git commit -m "chore: prepare Voyager 1.7.0"
+```
+
+### Task 2: Clean release verification and PR
+
+**Files:**
+- Verify only.
+
+- [ ] **Step 1: Run a clean complete local build**
+
+Run: `./gradlew clean testDebugUnitTest lintDebug assembleDebug assembleRelease --stacktrace`
+
+Expected: BUILD SUCCESSFUL with zero test or lint failures and a minified unsigned release APK.
+
+- [ ] **Step 2: Run full K60 instrumentation and debug smoke test**
+
+Run: `ANDROID_SERIAL=192.168.27.182:37713 ./gradlew connectedDebugAndroidTest --stacktrace`
+
+Install `app/build/outputs/apk/debug/app-universal-debug.apk`, force-stop and relaunch `com.voyagerfiles.debug`, confirm Settings displays 1.7.0, and repeat APK, archive, Open with, selection, SAF, and transfer-progress smoke tests.
+
+- [ ] **Step 3: Push and open the release PR**
+
+```bash
+git push -u origin codex/release-1.7.0
+gh pr create --base master --head codex/release-1.7.0 --title "Prepare Voyager 1.7.0" --body "Prepare the verified GitHub issues #39–#45 changes for release as Voyager 1.7.0."
+```
+
+- [ ] **Step 4: Wait for Android CI and merge only when green**
+
+Run: `release_pr_number=$(gh pr view codex/release-1.7.0 --json number --jq .number) && gh pr checks "$release_pr_number" --watch`
+
+Run: `gh pr merge "$release_pr_number" --merge --delete-branch`
+
+Expected: the release PR is merged and `origin/master` CI succeeds for its merge commit.
+
+### Task 3: Tag and monitor publication
+
+**Files:**
+- No source changes.
+
+- [ ] **Step 1: Resolve and verify the exact release merge commit**
+
+Run: `git fetch origin --tags && git switch master && git merge --ff-only origin/master && git log -1 --oneline && sed -n '27,34p' app/build.gradle.kts`
+
+Expected: HEAD is the merged release commit with version 1.7.0/code 15.
+
+- [ ] **Step 2: Create and push the release tag**
+
+Run: `git tag -a v1.7.0 -m "Voyager 1.7.0"`
+
+Run: `git push origin v1.7.0`
+
+- [ ] **Step 3: Wait for the release workflow**
+
+Run: `gh run list --workflow release.yml --limit 5`
+
+Run: `release_run_id=$(gh run list --workflow release.yml --branch v1.7.0 --limit 1 --json databaseId --jq '.[0].databaseId') && gh run watch "$release_run_id" --exit-status`
+
+Expected: `Android Release and Pages` completes successfully.
+
+- [ ] **Step 4: Verify GitHub release metadata and assets**
+
+Run: `gh release view v1.7.0 --json tagName,name,isDraft,isPrerelease,publishedAt,assets,url`
+
+Expected: non-draft, non-prerelease release with ABI APKs, universal APK, and `SHA256SUMS.txt`.
+
+### Task 4: Verify the published universal APK
+
+**Files:**
+- Download only to a temporary directory.
+
+- [ ] **Step 1: Download release assets into a temporary directory**
+
+Run: `release_tmp=$(mktemp -d) && gh release download v1.7.0 --dir "$release_tmp" && find "$release_tmp" -maxdepth 1 -type f -printf '%f\n' | sort`
+
+- [ ] **Step 2: Verify checksums**
+
+Run from the temporary directory: `sha256sum -c SHA256SUMS.txt`
+
+Expected: every asset reports OK.
+
+- [ ] **Step 3: Verify signing certificate and package version**
+
+Run: `apksigner verify --print-certs voyager-v1.7.0-universal.apk`
+
+Run: `aapt2 dump badging voyager-v1.7.0-universal.apk | sed -n '1,8p'`
+
+Expected: certificate SHA-256 `db496277d456751abe8ca6405026337c81a561a134e38d49c8e21fb8f036badf`, package `com.voyagerfiles`, versionCode 15, and versionName 1.7.0.
+
+- [ ] **Step 4: Install the production-signed APK over the existing production app and smoke-test**
+
+Run: `adb -s 192.168.27.182:37713 install -r voyager-v1.7.0-universal.apk`
+
+Force-stop and relaunch `com.voyagerfiles`, confirm version 1.7.0, and repeat the release-critical file-opening and SAF transfer checks.
+
+### Task 5: Pin F-Droid metadata
+
+**Files:**
+- Modify: `metadata/com.voyagerfiles.yml`
+
+**Interfaces:**
+- Consumes: the exact commit referenced by tag `v1.7.0`.
+- Produces: a version 1.7.0/code 15 build block and current-version fields.
+
+- [ ] **Step 1: Create a metadata branch from post-release master**
+
+Run: `git switch master && git merge --ff-only origin/master && git switch -c codex/sync-fdroid-1.7.0`
+
+- [ ] **Step 2: Resolve the immutable release commit**
+
+Run: `git rev-list -n 1 v1.7.0`
+
+Use the full 40-character output as the new build block's `commit` value.
+
+- [ ] **Step 3: Add the build block and current version**
+
+Append a build block with `versionName: 1.7.0`, `versionCode: 15`, the exact 40-character value printed by `git rev-list -n 1 v1.7.0`, `subdir: app`, `gradle: [yes]`, and `gradleprops: [voyager.enableAbiSplits=false]`. Set `CurrentVersion: 1.7.0` and `CurrentVersionCode: 15`.
+
+- [ ] **Step 4: Verify the metadata build source and universal configuration**
+
+Run: `git show v1.7.0:app/build.gradle.kts | rg 'versionCode = 15|versionName = "1.7.0"'`
+
+Run: `./gradlew assembleRelease -Pvoyager.enableAbiSplits=false --stacktrace`
+
+Expected: one universal unsigned release APK builds from the pinned source configuration.
+
+- [ ] **Step 5: Commit, push, open, verify, and merge the metadata PR**
+
+```bash
+git add metadata/com.voyagerfiles.yml
+git commit -m "chore: sync F-Droid metadata for 1.7.0"
+git push -u origin codex/sync-fdroid-1.7.0
+gh pr create --base master --head codex/sync-fdroid-1.7.0 --title "Sync F-Droid metadata for Voyager 1.7.0" --body "Pin the reproducible F-Droid build recipe to the verified Voyager 1.7.0 release commit."
+```
+
+Wait for CI, merge when green, and verify the final `master` workflow succeeds.

--- a/docs/superpowers/plans/2026-08-06-selection-feedback.md
+++ b/docs/superpowers/plans/2026-08-06-selection-feedback.md
@@ -1,0 +1,188 @@
+# Selection Feedback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add one tactile response when selection mode begins and restore reliable dynamic-theme contrast in the selection toolbar.
+
+**Architecture:** A pure transition function defines when haptics occur, and `BrowserScreen` applies it before forwarding selection changes to the ViewModel. Selection-toolbar Material colors are explicit at the point where the top app bar is constructed.
+
+**Tech Stack:** Kotlin, Jetpack Compose Foundation and Material 3, JUnit 4, AndroidX Compose UI tests.
+
+## Global Constraints
+
+- Emit one haptic only for the empty-to-nonempty selection transition.
+- List, compact-list, and grid modes use the same callback.
+- Selection navigation, title, and action icons use `onPrimaryContainer` over `primaryContainer`.
+- Keep existing row-selection colors and accessibility descriptions unchanged.
+
+---
+
+### Task 1: Selection transition policy
+
+**Files:**
+- Create: `app/src/test/java/com/voyagerfiles/ui/screens/SelectionFeedbackTest.kt`
+- Create: `app/src/main/java/com/voyagerfiles/ui/screens/SelectionFeedback.kt`
+
+**Interfaces:**
+- Produces: `shouldPerformSelectionHaptic(selectedPaths: Set<String>, toggledPath: String): Boolean`.
+
+- [ ] **Step 1: Write failing table-driven tests**
+
+```kotlin
+@Test
+fun hapticOccursOnlyWhenTheFirstItemBecomesSelected() {
+    assertTrue(shouldPerformSelectionHaptic(emptySet(), "/first"))
+    assertFalse(shouldPerformSelectionHaptic(setOf("/first"), "/second"))
+    assertFalse(shouldPerformSelectionHaptic(setOf("/first"), "/first"))
+}
+```
+
+- [ ] **Step 2: Run and verify compilation fails**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.ui.screens.SelectionFeedbackTest --stacktrace`
+
+Expected: compilation FAIL because the function is missing.
+
+- [ ] **Step 3: Implement the minimal policy**
+
+```kotlin
+internal fun shouldPerformSelectionHaptic(
+    selectedPaths: Set<String>,
+    toggledPath: String,
+): Boolean = selectedPaths.isEmpty() && toggledPath !in selectedPaths
+```
+
+- [ ] **Step 4: Run and verify the test passes**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.ui.screens.SelectionFeedbackTest --stacktrace`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/voyagerfiles/ui/screens/SelectionFeedback.kt app/src/test/java/com/voyagerfiles/ui/screens/SelectionFeedbackTest.kt
+git commit -m "test: define selection haptic policy"
+```
+
+### Task 2: Browser haptic wiring
+
+**Files:**
+- Modify: `app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt`
+- Modify: `app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserSelectionActionsTest.kt`
+
+**Interfaces:**
+- Consumes: `shouldPerformSelectionHaptic` and `LocalHapticFeedback`.
+
+- [ ] **Step 1: Add a Compose test that exercises the first-selection callback in list and grid mode**
+
+Use the existing real `BrowserScreen` fixture, enter selection from an empty set, and assert the toolbar appears with `1 selected` in both view modes. This protects the shared callback wiring while physical haptic output remains a device assertion.
+
+- [ ] **Step 2: Run the focused device test before wiring**
+
+Run: `ANDROID_SERIAL=192.168.27.182:37713 ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.voyagerfiles.ui.screens.BrowserSelectionActionsTest --stacktrace`
+
+Expected: the new grid/list transition test FAILS if it references the new shared callback semantics.
+
+- [ ] **Step 3: Wire one browser-level callback**
+
+```kotlin
+val hapticFeedback = LocalHapticFeedback.current
+
+fun toggleSelection(path: String) {
+    if (shouldPerformSelectionHaptic(state.selectedFiles, path)) {
+        hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+    }
+    viewModel.toggleSelection(path)
+}
+```
+
+Pass `::toggleSelection` from both list and grid click/long-click paths.
+
+- [ ] **Step 4: Run unit and device tests**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.ui.screens.SelectionFeedbackTest --stacktrace`
+
+Run: `ANDROID_SERIAL=192.168.27.182:37713 ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.voyagerfiles.ui.screens.BrowserSelectionActionsTest --stacktrace`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserSelectionActionsTest.kt
+git commit -m "feat: add selection-mode haptic feedback"
+```
+
+### Task 3: Dynamic-color toolbar contrast
+
+**Files:**
+- Modify: `app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt`
+- Modify: `app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserSelectionActionsTest.kt`
+
+**Interfaces:**
+- Produces: explicit `TopAppBarColors` with `primaryContainer` and `onPrimaryContainer`.
+
+- [ ] **Step 1: Add a low-chroma theme rendering test**
+
+Render the selection toolbar with a custom `lightColorScheme(primaryContainer = Color(0xFFAAAAAA), onPrimaryContainer = Color(0xFF101010))`, assert the title and all action semantics remain displayed, and capture the toolbar image for pixel inspection in the test assertion helper. The helper must assert that action-icon foreground pixels differ from the container by a WCAG contrast ratio of at least 3:1.
+
+- [ ] **Step 2: Run and verify the contrast test fails**
+
+Run: `ANDROID_SERIAL=192.168.27.182:37713 ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.voyagerfiles.ui.screens.BrowserSelectionActionsTest --stacktrace`
+
+Expected: FAIL because action icons inherit the low-contrast default observed in issue #41.
+
+- [ ] **Step 3: Set all selection-toolbar content colors explicitly**
+
+```kotlin
+colors = TopAppBarDefaults.topAppBarColors(
+    containerColor = MaterialTheme.colorScheme.primaryContainer,
+    navigationIconContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+    actionIconContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+)
+```
+
+- [ ] **Step 4: Run the contrast and selection tests**
+
+Run: `ANDROID_SERIAL=192.168.27.182:37713 ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.voyagerfiles.ui.screens.BrowserSelectionActionsTest --stacktrace`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserSelectionActionsTest.kt
+git commit -m "fix: restore selection toolbar contrast"
+```
+
+### Task 4: Verification and PR
+
+**Files:**
+- Modify: `docs/TESTING.md`
+
+- [ ] **Step 1: Add dynamic-gray and haptic checks to the manual matrix**
+
+Document that one haptic occurs when the first item is selected and that toolbar actions remain readable with the K60 gray dynamic palette.
+
+- [ ] **Step 2: Run the complete local and device gates**
+
+Run: `./gradlew testDebugUnitTest lintDebug assembleDebug assembleRelease --stacktrace`
+
+Run: `ANDROID_SERIAL=192.168.27.182:37713 ./gradlew connectedDebugAndroidTest --stacktrace`
+
+Expected: both commands complete successfully with zero failures.
+
+- [ ] **Step 3: Perform K60 visual and tactile verification**
+
+Install and restart the debug APK, use the gray Material You palette, long-press one file in list and grid modes, confirm one tactile response per transition into selection mode, and capture a screenshot showing readable close, title, rename/share/delete, and overflow controls.
+
+- [ ] **Step 4: Commit, review, push, and open PR**
+
+```bash
+git add docs/TESTING.md
+git commit -m "docs: cover selection feedback and contrast"
+git push -u origin codex/selection-feedback
+gh pr create --base master --head codex/selection-feedback --title "Improve selection feedback and contrast" --body "Closes #40\nCloses #41"
+```

--- a/docs/superpowers/plans/2026-08-06-transfer-correctness-progress.md
+++ b/docs/superpowers/plans/2026-08-06-transfer-correctness-progress.md
@@ -1,0 +1,321 @@
+# Transfer Correctness and Progress Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make cross-provider writes correct for opaque SAF identifiers and show truthful upload/download progress with transfer speed.
+
+**Architecture:** A provider-neutral stream-copy primitive reports bytes and monotonic elapsed time. The coordinator creates destination entries through `FileProvider` and writes only to returned identifiers; upload, paste, and download adapters publish those events as `TransferProgress` without inventing totals.
+
+**Tech Stack:** Kotlin coroutines, Android Storage Access Framework, provider abstractions for local/SFTP/FTP/SMB/WebDAV, JUnit 4, Compose Material 3.
+
+## Global Constraints
+
+- Missing, zero, and unknown sizes remain distinct.
+- Cross-provider writes never construct provider child identifiers with string concatenation.
+- Existing targets are never overwritten.
+- Partial destinations are removed after failure; move sources are deleted only after complete success.
+- Network and filesystem I/O stays on `Dispatchers.IO`.
+- Determinate progress appears only when the active stream has a trustworthy byte total.
+
+---
+
+### Task 1: Reproduce opaque destination failure
+
+**Files:**
+- Modify: `app/src/test/java/com/voyagerfiles/viewmodel/FileOperationCoordinatorTest.kt`
+
+**Interfaces:**
+- Produces: `OpaquePathProvider`, whose returned child paths cannot be derived from the parent path and filename.
+
+- [ ] **Step 1: Add failing file and directory copy tests**
+
+Create an in-memory provider whose `createFile("content://tree/root", "report.txt")` returns `FileItem(path = "content://tree/root/document/id-1")`, and whose `getOutputStream` rejects every non-created identifier. Assert file copy, recursive directory copy, upload, and cleanup use returned identifiers and preserve exact bytes.
+
+- [ ] **Step 2: Run and verify the root-cause failure**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.viewmodel.FileOperationCoordinatorTest --stacktrace`
+
+Expected: FAIL with an invalid destination identifier because the coordinator appends names to `content://tree/root`.
+
+- [ ] **Step 3: Commit the red test**
+
+```bash
+git add app/src/test/java/com/voyagerfiles/viewmodel/FileOperationCoordinatorTest.kt
+git commit -m "test: reproduce opaque SAF destination writes"
+```
+
+### Task 2: Provider-created destination identifiers
+
+**Files:**
+- Modify: `app/src/main/java/com/voyagerfiles/viewmodel/FileOperationCoordinator.kt`
+- Modify: `app/src/test/java/com/voyagerfiles/viewmodel/FileOperationCoordinatorTest.kt`
+
+**Interfaces:**
+- Produces: provider-neutral conflict lookup and returned-path recursive copy.
+
+- [ ] **Step 1: Implement destination-name conflict lookup**
+
+```kotlin
+private suspend fun requireNameAvailable(
+    provider: FileProvider,
+    directoryPath: String,
+    name: String,
+) {
+    if (provider.listFiles(directoryPath).getOrThrow().any { it.name == name }) {
+        throw DestinationConflictException(name)
+    }
+}
+```
+
+Adjust `DestinationConflictException` so it accepts either an identifier or a name while preserving the existing user-facing filename.
+
+- [ ] **Step 2: Create entries before opening their output streams**
+
+For files, call `requireNameAvailable`, then `createFile(destinationDirectoryPath, item.name)`, retain the returned `path`, and call `getOutputStream(created.path)`. For directories, use `createDirectory(...).path` as the recursive destination. Cleanup uses the returned path only.
+
+- [ ] **Step 3: Run coordinator tests**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.viewmodel.FileOperationCoordinatorTest --stacktrace`
+
+Expected: PASS, including opaque-path, no-overwrite, cleanup, and source-preservation cases.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/voyagerfiles/viewmodel/FileOperationCoordinator.kt app/src/test/java/com/voyagerfiles/viewmodel/FileOperationCoordinatorTest.kt
+git commit -m "fix: write through provider-created destinations"
+```
+
+### Task 3: Shared streaming progress primitive
+
+**Files:**
+- Create: `app/src/test/java/com/voyagerfiles/data/repository/StreamTransferTest.kt`
+- Create: `app/src/main/java/com/voyagerfiles/data/repository/StreamTransfer.kt`
+- Modify: `app/src/main/java/com/voyagerfiles/viewmodel/FileOperationCoordinator.kt`
+- Modify: `app/src/test/java/com/voyagerfiles/viewmodel/FileOperationCoordinatorTest.kt`
+
+**Interfaces:**
+- Produces: `StreamTransferProgress(path: String, bytesTransferred: Long, totalBytes: Long?, elapsedNanos: Long)` and `StreamTransfer.copy(input, output, path, totalBytes, nanoTime, onProgress)`.
+
+- [ ] **Step 1: Write failing progress tests with a deterministic clock**
+
+Assert a 131,089-byte payload reports strictly increasing bytes, a nondecreasing positive elapsed duration, exact total, exact final bytes, and no event before a failing output write. Assert an empty stream reports zero bytes with a known zero total.
+
+- [ ] **Step 2: Run and verify compilation fails**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.data.repository.StreamTransferTest --stacktrace`
+
+Expected: compilation FAIL because `StreamTransfer` is missing.
+
+- [ ] **Step 3: Implement bounded copy with monotonic time**
+
+```kotlin
+data class StreamTransferProgress(
+    val path: String,
+    val bytesTransferred: Long,
+    val totalBytes: Long?,
+    val elapsedNanos: Long,
+)
+```
+
+Use a 64 KiB buffer, call `output.write` before publishing each event, compute elapsed time from the injected monotonic clock, and publish one zero-byte event for an empty stream.
+
+- [ ] **Step 4: Replace coordinator-local stream copying**
+
+Delete `StreamCopyProgress` from `TransferProgress.kt`, update coordinator signatures to `StreamTransferProgress`, and preserve all current throttling consumers until later tasks enhance their display.
+
+- [ ] **Step 5: Run stream and coordinator tests**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.data.repository.StreamTransferTest --tests com.voyagerfiles.viewmodel.FileOperationCoordinatorTest --stacktrace`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/voyagerfiles/data/repository/StreamTransfer.kt app/src/test/java/com/voyagerfiles/data/repository/StreamTransferTest.kt app/src/main/java/com/voyagerfiles/viewmodel/FileOperationCoordinator.kt app/src/main/java/com/voyagerfiles/viewmodel/TransferProgress.kt app/src/test/java/com/voyagerfiles/viewmodel/FileOperationCoordinatorTest.kt
+git commit -m "refactor: share stream transfer progress"
+```
+
+### Task 4: Upload sizes and progress
+
+**Files:**
+- Create: `app/src/test/java/com/voyagerfiles/util/UploadSourceFactoryTest.kt`
+- Modify: `app/src/main/java/com/voyagerfiles/viewmodel/UploadSource.kt`
+- Modify: `app/src/main/java/com/voyagerfiles/util/UploadSourceFactory.kt`
+- Modify: `app/src/test/java/com/voyagerfiles/viewmodel/FileOperationCoordinatorTest.kt`
+- Modify: `app/src/main/java/com/voyagerfiles/viewmodel/FileOperationCoordinator.kt`
+- Modify: `app/src/main/java/com/voyagerfiles/viewmodel/FileBrowserViewModel.kt`
+
+**Interfaces:**
+- Produces: `UploadSource(name: String, size: Long? = null, openInputStream: () -> InputStream)` and upload `onProgress: (StreamTransferProgress) -> Unit`.
+
+- [ ] **Step 1: Write failing size and upload-progress tests**
+
+Use a real test `ContentProvider` cursor fixture with literal display name and size values. Assert a zero-length document yields `size = 0`, a null size yields `null`, and coordinator upload reports exact bytes and total without running on the caller thread.
+
+- [ ] **Step 2: Run focused tests and verify failure**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.util.UploadSourceFactoryTest --tests com.voyagerfiles.viewmodel.FileOperationCoordinatorTest --stacktrace`
+
+Expected: compilation or assertion FAIL because upload size and progress are absent.
+
+- [ ] **Step 3: Query `OpenableColumns.SIZE` without zero-filling nulls**
+
+Extend the content query projection to display name and size, use `cursor.isNull(sizeColumn)` to preserve unknown size, and pass the value into `UploadSource`.
+
+- [ ] **Step 4: Stream upload through `StreamTransfer.copy` and publish ViewModel progress**
+
+Add the callback to `uploadFile`, then update `uploadDocuments` with completed/total item counts, current filename, active-stream bytes, total, and elapsed duration. Reuse the existing byte publication threshold.
+
+- [ ] **Step 5: Run upload tests**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.util.UploadSourceFactoryTest --tests com.voyagerfiles.viewmodel.FileOperationCoordinatorTest --stacktrace`
+
+Run: `ANDROID_SERIAL=192.168.27.182:37713 ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.voyagerfiles.viewmodel.DocumentUploadTest --stacktrace`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/voyagerfiles/viewmodel/UploadSource.kt app/src/main/java/com/voyagerfiles/util/UploadSourceFactory.kt app/src/main/java/com/voyagerfiles/viewmodel/FileOperationCoordinator.kt app/src/main/java/com/voyagerfiles/viewmodel/FileBrowserViewModel.kt app/src/test/java/com/voyagerfiles/util/UploadSourceFactoryTest.kt app/src/test/java/com/voyagerfiles/viewmodel/FileOperationCoordinatorTest.kt
+git commit -m "feat: report upload progress"
+```
+
+### Task 5: Recursive download progress
+
+**Files:**
+- Modify: `app/src/test/java/com/voyagerfiles/data/remote/sftp/SftpFileProviderTest.kt`
+- Modify: `app/src/test/java/com/voyagerfiles/data/remote/webdav/WebDavFileProviderTest.kt`
+- Modify: `app/src/main/java/com/voyagerfiles/data/repository/FileDownloader.kt`
+- Modify: `app/src/main/java/com/voyagerfiles/viewmodel/FileBrowserViewModel.kt`
+
+**Interfaces:**
+- Consumes: `StreamTransfer.copy`.
+- Produces: `DownloadProgress(completedRequestedItems, totalRequestedItems, stream: StreamTransferProgress?)` callback from `FileDownloader.download`.
+
+- [ ] **Step 1: Add failing real-provider download progress assertions**
+
+For embedded SFTP and WebDAV fixtures, download a literal multi-buffer payload and assert the final event names the real remote path, reports exact bytes and total, and the output bytes match. Add a directory fixture and assert nested filenames appear while top-level completion reaches the requested item count.
+
+- [ ] **Step 2: Run and verify failure**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.data.remote.sftp.SftpFileProviderTest --tests com.voyagerfiles.data.remote.webdav.WebDavFileProviderTest --stacktrace`
+
+Expected: compilation FAIL because `FileDownloader.download` has no callback.
+
+- [ ] **Step 3: Add recursive download events**
+
+Stream every file through `StreamTransfer.copy`. Publish an item-start event with `stream = null`, forward stream events for nested files, and increment `completedRequestedItems` only after each requested top-level file or directory completes.
+
+- [ ] **Step 4: Publish download progress in the ViewModel**
+
+Map `DownloadProgress` into `TransferProgress(label = "Downloading", completedItems, totalItems, currentItemName, copiedBytes, totalBytes, elapsedNanos)` and preserve indeterminate progress for unknown totals.
+
+- [ ] **Step 5: Run provider and ViewModel tests**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.data.remote.sftp.SftpFileProviderTest --tests com.voyagerfiles.data.remote.webdav.WebDavFileProviderTest --stacktrace`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/voyagerfiles/data/repository/FileDownloader.kt app/src/main/java/com/voyagerfiles/viewmodel/FileBrowserViewModel.kt app/src/test/java/com/voyagerfiles/data/remote/sftp/SftpFileProviderTest.kt app/src/test/java/com/voyagerfiles/data/remote/webdav/WebDavFileProviderTest.kt
+git commit -m "feat: report recursive download progress"
+```
+
+### Task 6: Byte detail and transfer speed UI
+
+**Files:**
+- Modify: `app/src/test/java/com/voyagerfiles/viewmodel/TransferProgressTest.kt`
+- Modify: `app/src/main/java/com/voyagerfiles/viewmodel/TransferProgress.kt`
+- Modify: `app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserOperationProgressTest.kt`
+- Modify: `app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt`
+
+**Interfaces:**
+- Produces: `elapsedNanos`, `bytesPerSecond`, `byteProgressText`, and `speedText` on `TransferProgress`.
+
+- [ ] **Step 1: Write failing literal formatting tests**
+
+```kotlin
+@Test
+fun formatsTransferredBytesAndAverageSpeedWithoutInventingTotals() {
+    val known = TransferProgress("Downloading", copiedBytes = 1_572_864, totalBytes = 3_145_728, elapsedNanos = 1_500_000_000)
+    assertEquals("1.5 MB of 3 MB", known.byteProgressText)
+    assertEquals("1 MB/s", known.speedText)
+
+    val unknown = TransferProgress("Downloading", copiedBytes = 1_024, totalBytes = null, elapsedNanos = 1_000_000_000)
+    assertEquals("1 KB", unknown.byteProgressText)
+    assertEquals("1 KB/s", unknown.speedText)
+}
+```
+
+- [ ] **Step 2: Run and verify compilation fails**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.viewmodel.TransferProgressTest --stacktrace`
+
+Expected: compilation FAIL because elapsed and formatted properties are missing.
+
+- [ ] **Step 3: Implement truthful formatting**
+
+Require nonnegative elapsed duration, derive bytes per second only when elapsed and transferred bytes are positive, format with `FileItem.formatFileSize`, and append byte progress and speed to `detailText` and `stateDescription` without adding `0%` for unknown totals.
+
+- [ ] **Step 4: Update the Compose progress test**
+
+Render known and unknown totals and assert literal detail strings plus accessible `StateDescription` values include active filename, item count, byte progress, percentage when known, and speed.
+
+- [ ] **Step 5: Run unit and device progress tests**
+
+Run: `./gradlew testDebugUnitTest --tests com.voyagerfiles.viewmodel.TransferProgressTest --stacktrace`
+
+Run: `ANDROID_SERIAL=192.168.27.182:37713 ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.voyagerfiles.ui.screens.BrowserOperationProgressTest --stacktrace`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/voyagerfiles/viewmodel/TransferProgress.kt app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt app/src/test/java/com/voyagerfiles/viewmodel/TransferProgressTest.kt app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserOperationProgressTest.kt
+git commit -m "feat: show transfer bytes and speed"
+```
+
+### Task 7: Verification, SAF device reproduction, and PR
+
+**Files:**
+- Modify: `docs/ARCHITECTURE.md`
+- Modify: `docs/TESTING.md`
+
+- [ ] **Step 1: Update architecture and testing documentation**
+
+Document provider-created opaque destinations, byte/speed fields, unknown-total behavior, and the real SAF plus disposable SMB verification procedures.
+
+- [ ] **Step 2: Run the complete local gate**
+
+Run: `./gradlew testDebugUnitTest lintDebug assembleDebug assembleRelease --stacktrace`
+
+Expected: BUILD SUCCESSFUL with zero failures.
+
+- [ ] **Step 3: Run device instrumentation**
+
+Run: `ANDROID_SERIAL=192.168.27.182:37713 ./gradlew connectedDebugAndroidTest --stacktrace`
+
+Expected: BUILD SUCCESSFUL with zero failed tests.
+
+- [ ] **Step 4: Verify real SAF writes on K60**
+
+Create a disposable `VoyagerSafTest` document-tree folder through Android's picker, copy and move a small file and a nested directory from internal storage into it, verify exact server-side/device byte counts, then remove the disposable fixtures. Confirm no `rbDocOpen` or `EPERM` appears in logcat.
+
+- [ ] **Step 5: Verify SMB when credentials are configured**
+
+If every `VOYAGER_SMB_*` variable documented in `docs/TESTING.md` is present, run `./gradlew testDebugUnitTest --tests com.voyagerfiles.data.remote.smb.SmbFileProviderTest --stacktrace` and manually observe upload/download progress against the disposable share. If credentials are absent, record SMB integration as unavailable while relying on shared stream and embedded-provider coverage.
+
+- [ ] **Step 6: Commit, review, push, and open PR**
+
+```bash
+git add docs/ARCHITECTURE.md docs/TESTING.md
+git commit -m "docs: describe reliable transfer progress"
+git push -u origin codex/transfer-correctness-progress
+gh pr create --base master --head codex/transfer-correctness-progress --title "Fix SAF writes and report transfer progress" --body "Closes #44\nCloses #45"
+```

--- a/docs/superpowers/specs/2026-08-06-github-issues-39-45-design.md
+++ b/docs/superpowers/specs/2026-08-06-github-issues-39-45-design.md
@@ -1,0 +1,31 @@
+# GitHub issues 39–45 design
+
+## Scope
+
+Resolve every open Voyager issue as of 2026-08-06 and disposition pull request #46. Delivery is split into three focused pull requests so correctness, user interaction, and transfer-progress changes remain independently reviewable. Each pull request must add regression coverage, pass the complete local gate, and receive K60 device verification where Android platform behavior is involved.
+
+## Change set 1: file opening and archives
+
+Issues #39, #42, and #43 form one file-interaction change set. APK taps continue to use Android's normal view intent with a content URI, but Voyager declares `REQUEST_INSTALL_PACKAGES`, as required for callers targeting Android 8 or later. The contribution from pull request #46 is retained with its original author. Ordinary taps continue to honor Android defaults. A new single-selection “Open with” action wraps the same readable view intent in an Android chooser for local and SAF files, while remote files continue to require download first. Tapping a supported archive no longer attempts an external viewer; it opens a confirmation dialog describing the extraction destination, and confirmation invokes the existing safe archive service. Unsupported archive types keep the existing actionable message and are not presented as extractable.
+
+The implementation will centralize open-intent construction and archive-tap classification so list and grid layouts cannot diverge. Failures remain user-visible through the existing snackbar path. Tests will cover the manifest permission, direct versus chooser intents, action eligibility, archive-tap classification, confirmation UI, successful extraction, unsupported archives, and K60 package-installer launch.
+
+## Change set 2: selection feedback and contrast
+
+Issues #40 and #41 form one selection-mode polish change set. Entering selection mode from an empty selection emits one long-press haptic; selecting or deselecting additional rows does not emit extra transition haptics. This is owned by the browser-level selection callback so list and grid behavior is identical. The selection top app bar explicitly sets navigation, title, and action icon content colors to `onPrimaryContainer` rather than relying on Material defaults that can become low-contrast under neutral dynamic-color palettes. Selected rows and grids retain their existing background treatment.
+
+Tests will cover the empty-to-nonempty transition policy as a pure model, list and grid callback wiring, selection-toolbar semantics, and rendered selection-toolbar colors under a controlled low-chroma theme. K60 verification will use the device's dynamic gray palette and confirm one tactile response when selection begins.
+
+## Change set 3: SAF correctness and transfer progress
+
+Issues #44 and #45 form one transfer change set. Cross-provider uploads, copies, and moves must never derive destination identifiers by string concatenation. They first ask the destination provider to create the file or directory and then use the returned `FileItem.path`, which is valid for filesystem paths, network paths, and opaque SAF document URIs. On failure, cleanup uses that returned path; moves delete the source only after the complete destination succeeds. Existing conflict behavior remains non-overwriting.
+
+The shared streaming layer will report the active item, bytes transferred, optional trustworthy byte total, and monotonic elapsed time. Upload sources query `OpenableColumns.SIZE` when available. Remote downloads report recursively encountered files without performing an expensive preflight traversal. The ViewModel derives a stable average transfer rate from transferred bytes and elapsed monotonic time, throttles UI publication by both byte and time thresholds, and shows filename, item count, formatted byte progress, percentage when a total is known, and formatted speed. Unknown totals remain indeterminate and missing sizes are never converted to zero.
+
+Tests will use a provider with opaque child identifiers to reproduce the SAF failure before the fix, verify returned destination identifiers and cleanup, cover upload and recursive-download progress, validate speed and byte formatting, and exercise Compose accessibility state. Device verification will copy and move disposable files into a real SAF document tree. SMB behavior will be covered by the shared coordinator tests and the opt-in integration fixture when valid disposable credentials are configured.
+
+## Delivery and release
+
+Each change set is developed test-first on a `codex/` branch, reviewed, pushed, and opened as a pull request. Green pull requests are merged in order: file interaction, selection polish, then transfer correctness and progress. Pull request #46 is closed only after its authored change is preserved in the merged history. Issues close through explicit `Closes` references or a verified post-merge close action.
+
+After all three pull requests land, the release workflow follows the repository release documentation. Version declarations, changelog, metadata, minified release build, full JVM and lint gates, device instrumentation, release APK installation, and a final K60 smoke test must agree before a tag or GitHub release is published. Release notes remain factual and map directly to verified changes.


### PR DESCRIPTION
## Summary
- allow APK files to reach the system package installer while preserving the original contributor commit
- add an explicit Open with chooser for one selected local or SAF file
- confirm supported archive extraction on tap and explain unsupported formats
- stabilize device tests for scrollable content and document the regression coverage

## Verification
- `./gradlew testDebugUnitTest lintDebug assembleDebug assembleRelease --stacktrace`
- `ANDROID_SERIAL=192.168.27.182:37713 ./gradlew connectedDebugAndroidTest --stacktrace` (49 tests on Redmi K60, Android 16/API 36)
- manual K60 smoke test: APK installer, Android chooser, archive cancel, and archive extraction
- independent branch review: no actionable findings

Closes #39
Closes #42
Closes #43