### PR TITLE
Improve selection feedback and toolbar contrast

### DIFF
--- a/app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserSelectionActionsTest.kt
+++ b/app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserSelectionActionsTest.kt
@@ -1,13 +1,20 @@
 package com.voyagerfiles.ui.screens
 
 import android.app.Application
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -24,10 +31,14 @@ import java.io.File
 import java.io.FileOutputStream
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.pow
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -108,6 +119,33 @@ class BrowserSelectionActionsTest {
                 haptics.events,
             )
         }
+    }
+
+    @Test
+    fun selectionToolbarUsesContrastingContentColors() {
+        val containerColor = Color(0xFFAAAAAA)
+        val lowContrastDefaults = lightColorScheme(
+            primaryContainer = containerColor,
+            onPrimaryContainer = Color(0xFF101010),
+            onSurface = containerColor,
+            onSurfaceVariant = containerColor,
+        )
+        val viewModel = launchBrowser(colorScheme = lowContrastDefaults)
+        waitForRoot(viewModel)
+
+        composeTestRule.onNode(hasText("notes.txt") and hasClickAction())
+            .performTouchInput { longClick() }
+
+        composeTestRule.onNodeWithContentDescription("Clear selection").assertIsDisplayed()
+        composeTestRule.onNodeWithText("1 selected").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Rename").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Share").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Delete").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("More selection actions").assertIsDisplayed()
+        assertHasIconContrast(
+            image = composeTestRule.onNodeWithContentDescription("Delete").captureToImage(),
+            containerColor = containerColor,
+        )
     }
 
     @Test
@@ -281,11 +319,12 @@ class BrowserSelectionActionsTest {
 
     private fun launchBrowser(
         hapticFeedback: HapticFeedback? = null,
+        colorScheme: ColorScheme? = null,
     ): FileBrowserViewModel {
         val application = ApplicationProvider.getApplicationContext<Application>()
         val viewModel = FileBrowserViewModel(application)
         composeTestRule.setContent {
-            MaterialTheme {
+            val browserContent: @Composable () -> Unit = {
                 if (hapticFeedback == null) {
                     BrowserScreen(
                         viewModel = viewModel,
@@ -300,6 +339,11 @@ class BrowserSelectionActionsTest {
                     }
                 }
             }
+            if (colorScheme == null) {
+                MaterialTheme(content = browserContent)
+            } else {
+                MaterialTheme(colorScheme = colorScheme, content = browserContent)
+            }
         }
         composeTestRule.runOnIdle {
             viewModel.openLocalRoot(root.absolutePath)
@@ -313,6 +357,41 @@ class BrowserSelectionActionsTest {
                 !viewModel.browseState.value.isLoading
         }
         composeTestRule.onNodeWithText("notes.txt").assertExists()
+    }
+
+    private fun assertHasIconContrast(image: ImageBitmap, containerColor: Color) {
+        val pixels = image.toPixelMap()
+        var maximumContrast = 1.0
+        for (y in 0 until image.height) {
+            for (x in 0 until image.width) {
+                maximumContrast = max(
+                    maximumContrast,
+                    contrastRatio(pixels[x, y], containerColor),
+                )
+            }
+        }
+        assertTrue(
+            "Expected action icon contrast of at least 3:1, captured $maximumContrast:1",
+            maximumContrast >= 3.0,
+        )
+    }
+
+    private fun contrastRatio(first: Color, second: Color): Double {
+        val firstLuminance = relativeLuminance(first)
+        val secondLuminance = relativeLuminance(second)
+        return (max(firstLuminance, secondLuminance) + 0.05) /
+            (min(firstLuminance, secondLuminance) + 0.05)
+    }
+
+    private fun relativeLuminance(color: Color): Double =
+        0.2126 * linearize(color.red) +
+            0.7152 * linearize(color.green) +
+            0.0722 * linearize(color.blue)
+
+    private fun linearize(channel: Float): Double = if (channel <= 0.04045f) {
+        channel / 12.92
+    } else {
+        ((channel + 0.055) / 1.055).toDouble().pow(2.4)
     }
 
     private class RecordingHapticFeedback : HapticFeedback {

--- a/app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserSelectionActionsTest.kt
+++ b/app/src/androidTest/java/com/voyagerfiles/ui/screens/BrowserSelectionActionsTest.kt
@@ -2,6 +2,9 @@ package com.voyagerfiles.ui.screens
 
 import android.app.Application
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.hapticfeedback.HapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.assertIsDisplayed
@@ -12,6 +15,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.test.core.app.ApplicationProvider
 import com.voyagerfiles.data.local.PreferencesManager
 import com.voyagerfiles.data.model.ViewMode
@@ -22,6 +26,7 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 import kotlinx.coroutines.runBlocking
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Before
 import org.junit.Rule
@@ -69,6 +74,40 @@ class BrowserSelectionActionsTest {
         composeTestRule.onNodeWithContentDescription("Share").assertExists()
         composeTestRule.onNodeWithContentDescription("Rename").assertExists()
         composeTestRule.onNodeWithContentDescription("Delete").assertExists()
+    }
+
+    @Test
+    fun firstSelectionPerformsOneHapticInListAndGridModes() {
+        val haptics = RecordingHapticFeedback()
+        val viewModel = launchBrowser(haptics)
+        waitForRoot(viewModel)
+        composeTestRule.runOnIdle { viewModel.setViewMode(ViewMode.LIST) }
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            viewModel.browseState.value.viewMode == ViewMode.LIST
+        }
+
+        composeTestRule.onNode(hasText("notes.txt") and hasClickAction())
+            .performTouchInput { longClick() }
+        composeTestRule.onNodeWithText("1 selected").assertIsDisplayed()
+        composeTestRule.runOnIdle {
+            assertEquals(listOf(HapticFeedbackType.LongPress), haptics.events)
+            viewModel.clearSelection()
+            viewModel.setViewMode(ViewMode.GRID)
+        }
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            viewModel.browseState.value.viewMode == ViewMode.GRID &&
+                viewModel.browseState.value.selectedFiles.isEmpty()
+        }
+
+        composeTestRule.onNode(hasText("notes.txt") and hasClickAction())
+            .performTouchInput { longClick() }
+        composeTestRule.onNodeWithText("1 selected").assertIsDisplayed()
+        composeTestRule.runOnIdle {
+            assertEquals(
+                listOf(HapticFeedbackType.LongPress, HapticFeedbackType.LongPress),
+                haptics.events,
+            )
+        }
     }
 
     @Test
@@ -240,15 +279,26 @@ class BrowserSelectionActionsTest {
             .assertIsDisplayed()
     }
 
-    private fun launchBrowser(): FileBrowserViewModel {
+    private fun launchBrowser(
+        hapticFeedback: HapticFeedback? = null,
+    ): FileBrowserViewModel {
         val application = ApplicationProvider.getApplicationContext<Application>()
         val viewModel = FileBrowserViewModel(application)
         composeTestRule.setContent {
             MaterialTheme {
-                BrowserScreen(
-                    viewModel = viewModel,
-                    onNavigateBack = {},
-                )
+                if (hapticFeedback == null) {
+                    BrowserScreen(
+                        viewModel = viewModel,
+                        onNavigateBack = {},
+                    )
+                } else {
+                    CompositionLocalProvider(LocalHapticFeedback provides hapticFeedback) {
+                        BrowserScreen(
+                            viewModel = viewModel,
+                            onNavigateBack = {},
+                        )
+                    }
+                }
             }
         }
         composeTestRule.runOnIdle {
@@ -263,5 +313,13 @@ class BrowserSelectionActionsTest {
                 !viewModel.browseState.value.isLoading
         }
         composeTestRule.onNodeWithText("notes.txt").assertExists()
+    }
+
+    private class RecordingHapticFeedback : HapticFeedback {
+        val events = mutableListOf<HapticFeedbackType>()
+
+        override fun performHapticFeedback(hapticFeedbackType: HapticFeedbackType) {
+            events += hapticFeedbackType
+        }
     }
 }

--- a/app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt
+++ b/app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt
@@ -478,6 +478,9 @@ fun BrowserScreen(
                     },
                     colors = TopAppBarDefaults.topAppBarColors(
                         containerColor = MaterialTheme.colorScheme.primaryContainer,
+                        navigationIconContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                        titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                        actionIconContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
                     ),
                 )
             } else {

--- a/app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt
+++ b/app/src/main/java/com/voyagerfiles/ui/screens/BrowserScreen.kt
@@ -90,8 +90,10 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.style.TextOverflow
@@ -139,6 +141,7 @@ fun BrowserScreen(
     val operationState by viewModel.operationState.collectAsState()
     val context = LocalContext.current
     val focusManager = LocalFocusManager.current
+    val hapticFeedback = LocalHapticFeedback.current
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
     val uploadLauncher = rememberLauncherForActivityResult(
@@ -178,6 +181,13 @@ fun BrowserScreen(
     }
     val toolbarModel = remember(isNetwork) { BrowserToolbarModel.forState(isNetwork) }
     val createMenuModel = remember(isNetwork) { BrowserCreateMenuModel.forState(isNetwork) }
+
+    fun toggleSelection(path: String) {
+        if (shouldPerformSelectionHaptic(state.selectedFiles, path)) {
+            hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+        }
+        viewModel.toggleSelection(path)
+    }
     val selectionToolbarModel = remember(isNetwork, selectedItems.size, sharePlan, canOpenWith) {
         SelectionToolbarModel.forState(
             isRemote = isNetwork,
@@ -803,7 +813,7 @@ fun BrowserScreen(
                                 isSelectionMode = isSelectionMode,
                                 onClick = {
                                     if (isSelectionMode) {
-                                        viewModel.toggleSelection(file.path)
+                                        toggleSelection(file.path)
                                     } else if (file.isDirectory) {
                                         navigateTo(file.path)
                                     } else if (isNetwork) {
@@ -813,7 +823,7 @@ fun BrowserScreen(
                                     }
                                 },
                                 onLongClick = {
-                                    viewModel.toggleSelection(file.path)
+                                    toggleSelection(file.path)
                                 },
                             )
                         }
@@ -835,7 +845,7 @@ fun BrowserScreen(
                                 isSelectionMode = isSelectionMode,
                                 onClick = {
                                     if (isSelectionMode) {
-                                        viewModel.toggleSelection(file.path)
+                                        toggleSelection(file.path)
                                     } else if (file.isDirectory) {
                                         navigateTo(file.path)
                                     } else if (isNetwork) {
@@ -845,7 +855,7 @@ fun BrowserScreen(
                                     }
                                 },
                                 onLongClick = {
-                                    viewModel.toggleSelection(file.path)
+                                    toggleSelection(file.path)
                                 },
                             )
                         }

--- a/app/src/main/java/com/voyagerfiles/ui/screens/SelectionFeedback.kt
+++ b/app/src/main/java/com/voyagerfiles/ui/screens/SelectionFeedback.kt
@@ -1,0 +1,6 @@
+package com.voyagerfiles.ui.screens
+
+internal fun shouldPerformSelectionHaptic(
+    selectedPaths: Set<String>,
+    toggledPath: String,
+): Boolean = selectedPaths.isEmpty() && toggledPath !in selectedPaths

--- a/app/src/test/java/com/voyagerfiles/ui/screens/SelectionFeedbackTest.kt
+++ b/app/src/test/java/com/voyagerfiles/ui/screens/SelectionFeedbackTest.kt
@@ -1,0 +1,15 @@
+package com.voyagerfiles.ui.screens
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SelectionFeedbackTest {
+
+    @Test
+    fun hapticOccursOnlyWhenTheFirstItemBecomesSelected() {
+        assertTrue(shouldPerformSelectionHaptic(emptySet(), "/first"))
+        assertFalse(shouldPerformSelectionHaptic(setOf("/first"), "/second"))
+        assertFalse(shouldPerformSelectionHaptic(setOf("/first"), "/first"))
+    }
+}

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -34,7 +34,7 @@ adb connect DEVICE_ADDRESS:WIRELESS_DEBUGGING_PORT
 ANDROID_SERIAL=DEVICE_ADDRESS:WIRELESS_DEBUGGING_PORT ./gradlew connectedDebugAndroidTest --stacktrace
 ```
 
-Instrumentation installs the debug package `com.voyagerfiles.debug`. The current tests exercise direct Android file-open intents, the explicit Open with chooser, APK installer permission, generated SFTP public-key export, image and first-page PDF thumbnails, determinate and indeterminate operation progress, archive naming, direct and selection-based ZIP extraction, archive-tap confirmation and cancellation, unavailable-storage presentation, saved-connection and file-delete confirmations, single and multiple share intents, contextual selection actions, permanent local deletion, compact-view persistence, file details, parent navigation after using search, selection-control accessibility labels, and Android Keystore encryption.
+Instrumentation installs the debug package `com.voyagerfiles.debug`. The current tests exercise direct Android file-open intents, the explicit Open with chooser, APK installer permission, generated SFTP public-key export, image and first-page PDF thumbnails, determinate and indeterminate operation progress, archive naming, direct and selection-based ZIP extraction, archive-tap confirmation and cancellation, unavailable-storage presentation, saved-connection and file-delete confirmations, single and multiple share intents, contextual selection actions, first-selection haptic dispatch, selection-toolbar contrast, permanent local deletion, compact-view persistence, file details, parent navigation after using search, selection-control accessibility labels, and Android Keystore encryption.
 
 Run the issue-focused device coverage with:
 
@@ -84,7 +84,7 @@ Use disposable files and keep device orientation unlocked unless a case calls fo
 | Trash | For a direct-local selection, verify both Trash and permanent choices; move a file to Trash, restore it, create a restore conflict, permanently delete an entry, empty Trash, and repeat with Trash disabled. |
 | Error recovery | Remove or unmount a location while browsing, deny a SAF operation, open an unsupported file, use a bad remote hostname, and verify retry or actionable feedback. |
 | Remote | Generate an SFTP key, copy and save its public key, authenticate with it while leaving the password blank, verify first-use pinning and changed-key rejection, verify FTP cleartext confirmation, HTTPS WebDAV on a custom port, HTTP warning, large transfers, and a connection delete confirmation. |
-| Layout and accessibility | Test portrait and landscape, large font and display sizes, List, Compact list, and Grid persistence, TalkBack labels, 48 dp touch targets, loading indicators, empty states, selection mode, view menus, details sheets, dialogs, and keyboard focus where available. |
+| Layout and accessibility | Test portrait and landscape, large font and display sizes, List, Compact list, and Grid persistence, TalkBack labels, 48 dp touch targets, loading indicators, empty states, selection mode, view menus, details sheets, dialogs, and keyboard focus where available; in each layout, verify that the first selected item produces one haptic response and later selection changes do not, then apply a low-chroma gray dynamic palette and confirm the selection close button, count, actions, and overflow icon remain readable. |
 
 ## Useful device commands
 


### PR DESCRIPTION
## Summary

- emit one haptic response when selection mode begins across list, compact-list, and grid layouts
- use explicit Material color roles for readable selection-toolbar navigation, title, and actions
- add callback and pixel-contrast regression coverage plus device-testing guidance

## Verification

- `./gradlew testDebugUnitTest lintDebug assembleDebug assembleRelease --stacktrace`
- `ANDROID_SERIAL=192.168.27.182:37713 ./gradlew connectedDebugAndroidTest --stacktrace` (51 tests)
- Redmi K60 manual smoke: one recorded heavy-click vibration per transition into selection mode in list and grid layouts, no extra vibration when adding another item, and readable controls under the device dynamic palette
- independent code review found no actionable issues

Closes #40
Closes #41