### PR TITLE
Prepare Voyager 1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ An open-source Android file manager for local storage, document trees, SFTP, FTP
 - Continue without broad storage access and use Storage Access Framework document trees or remote servers in limited mode.
 - Switch among list, compact list, and grid layouts, view image and first-page PDF thumbnails, show hidden files, sort by name, size, date, or type, and search the current folder.
 - Filter a folder by directories, images, videos, audio, documents, archives, or Android packages.
-- Select visible results, share local or document-tree files, inspect file details, copy, move, rename, delete, and create files and folders, including cross-provider transfers with visible progress.
+- Select visible results, share local or document-tree files, inspect file details, copy, move, rename, delete, and create files and folders, including cross-provider transfers with filenames, bytes, percentage, and speed.
 - Create ZIP archives and safely extract ZIP, TAR, TGZ, TAR.GZ, TBZ2, TAR.BZ2, GZ, and BZ2 files on local, document-tree, or remote providers. RAR files are recognized and reported as unsupported.
-- Open local and document-tree files through Android's registered handlers so Android's default-app choices are honored.
+- Open local and document-tree files through Android's registered handlers so Android's default-app choices are honored, or explicitly choose a handler with Open with. APK files open in Android's package installer.
 - Choose Trash or permanent deletion for each direct-local operation, restore recoverable per-volume Trash items, or disable Trash in Settings.
 - Bookmark local folders, open common media locations, customize the visibility and order of Home sections, and keep several local, document-tree, or remote browser sessions open.
 - Automatically close inactive browser sessions after Voyager remains in the background for a chosen duration.
-- Connect to SFTP, FTP, SMB, and WebDAV servers, create remote files and folders, upload Android documents, and download remote files or directories to Android's Downloads folder.
+- Connect to SFTP, FTP, SMB, and WebDAV servers, create remote files and folders, upload Android documents, and download remote files or directories to Android's Downloads folder with visible transfer progress.
 - Authenticate to SFTP with a password, keyboard-interactive authentication, a private key file, or an in-app generated key pair whose public key can be copied or saved.
 - Choose from 20 included color schemes, including AMOLED black and high-contrast options, with Material You dynamic colors on Android 12 and later.
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,8 +28,8 @@ android {
         applicationId = "com.voyagerfiles"
         minSdk = 26
         targetSdk = 35
-        versionCode = 14
-        versionName = "1.6.0"
+        versionCode = 15
+        versionName = "1.7.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/fastlane/metadata/android/en-US/changelogs/15.txt
+++ b/fastlane/metadata/android/en-US/changelogs/15.txt
@@ -1,0 +1,5 @@
+Voyager 1.7.0:
+- Open APK files, choose an app with Open with, and confirm archive extraction
+- Improve selection haptics and dynamic-theme toolbar contrast
+- Fix writes into Storage Access Framework document trees
+- Show file names, bytes, percentage, and speed during uploads and downloads

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -4,15 +4,18 @@ Features:
 • Local file browsing with file management (copy, move, rename, Trash, permanent delete, create)
 • Share one or several local and document-tree files through Android's system share sheet
 • File details with selectable metadata
-• Image thumbnails for local image files
-• Storage Access Framework document-tree browsing
-• SFTP remote access, with password, keyboard-interactive, private key, or generated key-pair authentication
+• Image and first-page PDF thumbnails
+• Storage Access Framework document-tree browsing and file management
+• Open files through Android defaults or choose a handler with Open with
+• Create ZIP archives and safely extract ZIP, TAR, TGZ, TBZ2, GZ, and BZ2 files
+• SFTP remote access, with password, keyboard-interactive, private key, or generated key-pair authentication whose public key can be copied or saved
 • FTP remote access
 • SMB/CIFS network share browsing
 • WebDAV remote access
 • Copy and move files between local storage and a remote server, in both directions
 • Create remote files and folders, and upload documents through Android's system picker
 • Download remote files and folders to the device
+• Upload and download progress with active filenames, item counts, bytes, percentage when known, and speed
 • Multiple browser sessions for local and remote locations, with a session switcher
 • Optional automatic closure of inactive sessions after Voyager remains in the background
 • Mounted external storage volumes, such as SD cards and USB/OTG, listed alongside internal storage

--- a/metadata/en-US/changelogs/15.txt
+++ b/metadata/en-US/changelogs/15.txt
@@ -1,0 +1,5 @@
+Voyager 1.7.0:
+- Open APK files, choose an app with Open with, and confirm archive extraction
+- Improve selection haptics and dynamic-theme toolbar contrast
+- Fix writes into Storage Access Framework document trees
+- Show file names, bytes, percentage, and speed during uploads and downloads


### PR DESCRIPTION
## Summary

- set Voyager versionCode 15 and versionName 1.7.0
- add matching 292-byte F-Droid and repository changelogs for the verified issue #39 through #45 fixes
- refresh README and store feature descriptions for Open with, archive handling, SAF writes, generated SFTP public keys, and truthful transfer detail

## Verification

- `./gradlew clean testDebugUnitTest lintDebug assembleDebug assembleRelease --stacktrace`
- `ANDROID_SERIAL=192.168.27.182:37713 ./gradlew connectedDebugAndroidTest --stacktrace` (53 tests, 0 failures, 0 skips)
- packaged debug APK and K60 package manager report versionCode 15/versionName 1.7.0; Settings visibly shows Version 1.7.0
- K60 smoke reached Android package installation, archive extraction confirmation, selection mode, and the Open with system chooser
- K60 SAF copy on the versioned build matched SHA-256 exactly; a clean repeated write produced no `rbDocOpen`, `EPERM`, file, or provider security error
- both changelogs are byte-identical and below 500 bytes
