### PR TITLE
Sync F-Droid metadata for Voyager 1.8.0

### DIFF
--- a/metadata/com.voyagerfiles.yml
+++ b/metadata/com.voyagerfiles.yml
@@ -96,9 +96,23 @@ Builds:
     gradleprops:
       - voyager.enableAbiSplits=false
 
+  - versionName: 1.8.0
+    versionCode: 16
+    commit: d78f5c0f9d1143154d7a28aa8de5b27aa1d87f70
+    subdir: app
+    sudo:
+      - export CPUS_MAX=16
+      - export CPUS=$(getconf _NPROCESSORS_ONLN)
+      - for (( c=$CPUS_MAX; c<$CPUS; c++ )) ; do echo 0 > /sys/devices/system/cpu/cpu$c/online
+        ; done
+    gradle:
+      - yes
+    gradleprops:
+      - voyager.enableAbiSplits=false
+
 AllowedAPKSigningKeys: db496277d456751abe8ca6405026337c81a561a134e38d49c8e21fb8f036badf
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
-CurrentVersion: 1.7.0
-CurrentVersionCode: 15
+CurrentVersion: 1.8.0
+CurrentVersionCode: 16


### PR DESCRIPTION
Pin the reproducible F-Droid recipe to the verified Voyager 1.8.0 release commit.