### PR TITLE
Allow external editors to save writable local files

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ An open-source Android file manager for local storage, document trees, SFTP, FTP
 - Filter a folder by directories, images, videos, audio, documents, archives, or Android packages.
 - Select visible results, share local or document-tree files, inspect file details, copy, move, rename, delete, and create files and folders, including cross-provider transfers with filenames, bytes, percentage, and speed.
 - Create ZIP archives and safely extract ZIP, TAR, TGZ, TAR.GZ, TBZ2, TAR.BZ2, GZ, and BZ2 files on local, document-tree, or remote providers. RAR files are recognized and reported as unsupported.
-- Open local and document-tree files through Android's registered handlers so Android's default-app choices are honored, or explicitly choose a handler with Open with. APK files open in Android's package installer.
+- Open local and document-tree files through Android's registered handlers so Android's default-app choices are honored, or explicitly choose a handler with Open with. Writable local files receive temporary write permission so an external editor can save changes; Share grants read access only. APK files open in Android's package installer.
 - Choose Trash or permanent deletion for each direct-local operation, restore recoverable per-volume Trash items, or disable Trash in Settings.
 - Bookmark local folders, open common media locations, customize the visibility and order of Home sections, and keep several local, document-tree, or remote browser sessions open.
 - Automatically close inactive browser sessions after Voyager remains in the background for a chosen duration.

--- a/app/src/androidTest/java/com/voyagerfiles/ui/components/RemoteSelectKeyHandlerTest.kt
+++ b/app/src/androidTest/java/com/voyagerfiles/ui/components/RemoteSelectKeyHandlerTest.kt
@@ -67,6 +67,7 @@ class RemoteSelectKeyHandlerTest {
 
     private fun renderItem(grid: Boolean): MutableList<String> {
         val events = Collections.synchronizedList(mutableListOf<String>())
+        InstrumentationRegistry.getInstrumentation().setInTouchMode(false)
         composeTestRule.setContent {
             MaterialTheme {
                 val modifier = Modifier.testTag(TARGET_TAG)

--- a/app/src/androidTest/java/com/voyagerfiles/util/FileSharingTest.kt
+++ b/app/src/androidTest/java/com/voyagerfiles/util/FileSharingTest.kt
@@ -30,6 +30,42 @@ class FileSharingTest {
     }
 
     @Test
+    fun writableLocalFileCanBeEditedThroughOpenWith() {
+        val file = createLocalFile("editable.txt")
+        val chooser = FileUtils.createOpenWithIntent(context, file).getOrThrow()
+        val target = chooser.getParcelableExtra(Intent.EXTRA_INTENT, Intent::class.java)!!
+
+        assertTrue(target.flags and Intent.FLAG_GRANT_WRITE_URI_PERMISSION != 0)
+        assertTrue(chooser.flags and Intent.FLAG_GRANT_WRITE_URI_PERMISSION != 0)
+        context.contentResolver.openOutputStream(target.data!!, "wt")!!.use {
+            it.write("edited".toByteArray())
+        }
+        assertEquals("edited", File(file.path).readText())
+    }
+
+    @Test
+    fun readOnlyLocalFileDoesNotOfferWritePermission() {
+        val file = createLocalFile("readonly.txt")
+        val local = File(file.path)
+        assertTrue(local.setWritable(false, false))
+        try {
+            assertFalse(local.canWrite())
+            val intent = FileUtils.createOpenFileIntent(context, file).getOrThrow()
+            assertTrue(intent.flags and Intent.FLAG_GRANT_READ_URI_PERMISSION != 0)
+            assertEquals(0, intent.flags and Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+        } finally {
+            local.setWritable(true, true)
+        }
+    }
+
+    @Test
+    fun sharingWritableLocalFilesRemainsReadOnly() {
+        val intent = FileUtils.createShareIntent(context, listOf(createLocalFile("shared.txt")))
+            .getOrThrow()
+        assertEquals(0, intent.flags and Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+    }
+
+    @Test
     fun multipleLocalFilesBuildReadableSendMultipleIntent() {
         val files = listOf(createLocalFile("one.jpg"), createLocalFile("two.png"))
 

--- a/app/src/main/java/com/voyagerfiles/util/FileUtils.kt
+++ b/app/src/main/java/com/voyagerfiles/util/FileUtils.kt
@@ -134,6 +134,9 @@ object FileUtils {
         Intent(Intent.ACTION_VIEW).apply {
             setDataAndType(uri, file.mimeType)
             addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            if (file.source == FileSource.LOCAL && File(file.path).canWrite()) {
+                addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+            }
         }
     }
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -106,6 +106,8 @@ Use Android's document-tree picker to create or select a disposable `VoyagerSafT
 
 Use disposable files and keep device orientation unlocked unless a case calls for a fixed orientation.
 
+For external editing, open a writable local text file with an editor through Open with, save changes, and verify the source bytes. A read-only local file must not receive write permission, and Share must remain read-only. The remote-key instrumentation fixture explicitly leaves touch mode before requesting focus so its result does not depend on whether earlier tests used touch input.
+
 | Area | Cases |
 | --- | --- |
 | Permission | Deny full access, continue in limited mode, open a SAF tree, open a remote screen, return to Settings, then grant full access. |


### PR DESCRIPTION
Opening a writable local file in an external editor previously supplied only a read grant, so saving through Voyager's FileProvider URI failed. Open and Open with now grant temporary write access when the local file is writable. Read-only local files and Share intents retain read-only grants.

Android regression coverage checks the chooser and target grants, writes edited bytes through the content URI, and verifies the read-only cases. The existing remote-key test fixture now leaves touch mode before requesting focus, matching keyboard/TV input and removing a test-order dependency found during the full device run.

Validation:

- Reproduced #65 on a K60 running Android 16 with a failing writable-file regression test, then verified the fix.
- Full local gate with the reviewed changes from #63, #81, and #85 integrated: unit tests, lint, debug and minified release builds, and connected Android tests passed.
- JVM results: 227 tests, 4 environment-gated skips, 0 failures. Android results: 84 tests, 1 SMB fixture skip, 0 failures.
- Manually reviewed the integrated debug app on the K60. External-editor intent and URI writes are covered by instrumentation; compatibility with every third-party editor is not claimed.

Fixes #65.
