### PR TITLE
Connect Crowdin translation synchronization

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,0 +1,79 @@
+name: Crowdin translations
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - app/src/main/res/values/strings.xml
+      - crowdin.yml
+      - .github/workflows/crowdin.yml
+  schedule:
+    - cron: '23 6 * * *'
+  workflow_dispatch:
+    inputs:
+      import_existing:
+        description: Import repository translations into Crowdin (initial setup only)
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: crowdin-translations
+  cancel-in-progress: false
+
+jobs:
+  synchronize:
+    if: github.repository == 'AlanHuang99/Voyager' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: master
+
+      - name: Synchronize resources
+        uses: crowdin/github-action@0d5670f539973aea2f01abce61a8989934df0025 # v3
+        with:
+          user: auto
+          upload_sources: true
+          upload_translations: ${{ github.event_name == 'workflow_dispatch' && inputs.import_existing }}
+          import_eq_suggestions: true
+          download_translations: ${{ github.event_name != 'push' }}
+          skip_untranslated_strings: false
+          skip_untranslated_files: false
+          push_translations: false
+          create_pull_request: false
+        env:
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+
+      - name: Set up JDK 17
+        if: github.event_name != 'push'
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: temurin
+
+      - name: Set up Gradle
+        if: github.event_name != 'push'
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Validate translations
+        if: github.event_name != 'push'
+        run: ./gradlew testDebugUnitTest lintDebug assembleDebug assembleRelease --stacktrace
+
+      - name: Open translation pull request
+        if: github.event_name != 'push'
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
+        with:
+          branch: codex/crowdin-translations
+          base: master
+          add-paths: app/src/main/res/values-*/strings.xml
+          commit-message: Update translations
+          title: Update translations
+          body: Translation updates from the Voyager Crowdin project. The synchronization workflow runs unit tests, lint, and debug and release builds before opening or updating this pull request.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Run the complete local gate before submitting a change:
 ./gradlew testDebugUnitTest lintDebug assembleDebug assembleRelease
 ```
 
-See [docs/TESTING.md](docs/TESTING.md) for device and protocol testing, [docs/TRANSLATING.md](docs/TRANSLATING.md) for the translation workflow, [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the app structure and security boundaries, and [docs/RELEASE.md](docs/RELEASE.md) for release mechanics.
+See [docs/TESTING.md](docs/TESTING.md) for device and protocol testing, [docs/TRANSLATING.md](docs/TRANSLATING.md) for the translation workflow and [Crowdin](https://crowdin.com/project/voyagerandroid) to contribute translations, [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the app structure and security boundaries, and [docs/RELEASE.md](docs/RELEASE.md) for release mechanics.
 
 ## Tech stack
 

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,13 @@
+project_id: '927407'
+api_token_env: CROWDIN_PERSONAL_TOKEN
+base_path: .
+preserve_hierarchy: true
+
+files:
+  - source: /app/src/main/res/values/strings.xml
+    translation: /app/src/main/res/values-%android_code%/strings.xml
+    type: android
+    languages_mapping:
+      android_code:
+        fr: fr
+        zh-CN: zh-rCN

--- a/docs/TRANSLATING.md
+++ b/docs/TRANSLATING.md
@@ -2,7 +2,17 @@
 
 Voyager keeps user-facing copy in `app/src/main/res/values/strings.xml`. A translation should preserve the meaning and tone of the default English resources while fitting naturally in the target language.
 
-## Add a locale
+## Translate with Crowdin
+
+Join [Voyager on Crowdin](https://crowdin.com/project/voyagerandroid) to translate or review strings in the browser. English is the source language. Existing French and Simplified Chinese resources are imported during initial setup so their contributors' work is preserved.
+
+The repository's `crowdin.yml` maps Android resources to `values-%android_code%/strings.xml`, with explicit mappings for French (`values-fr`) and Simplified Chinese (`values-zh-rCN`). Resources marked `translatable="false"` remain in the English source file. Untranslated strings are exported with English source text so incomplete locales can pass Android's missing-translation checks. Crowdin retains their untranslated status.
+
+The Crowdin translations workflow uploads English resource changes from `master`. It downloads translations daily, runs unit tests, lint, and debug and release builds, and opens or updates a translation pull request. Translation pull requests require review and are not merged automatically. These checks run in the synchronization workflow itself because pull requests created with `GITHUB_TOKEN` do not trigger the regular pull request workflow.
+
+Maintainers can run the workflow manually from GitHub Actions. For the initial import, enable **Import repository translations into Crowdin** once. Leave it disabled for normal synchronization to avoid reimporting older repository translations. The project ID is `927407`; the token is stored only in the repository's `CROWDIN_PERSONAL_TOKEN` Actions secret. The repository must allow GitHub Actions to create pull requests.
+
+## Add a locale directly
 
 Copy the default resource file into an Android locale directory, then translate its values. For example, French uses `app/src/main/res/values-fr/strings.xml`, Brazilian Portuguese uses `values-pt-rBR`, and Traditional Chinese for Taiwan uses `values-zh-rTW`.
 


### PR DESCRIPTION
Connects the Voyager Crowdin project (927407) to the Android English source resources and existing French and Simplified Chinese locale paths. Source changes upload from master; daily or manual synchronization validates translations with unit tests, lint, and debug and release builds before opening a reviewable pull request. A manual setup input imports existing translations once.

The workflow reads CROWDIN_PERSONAL_TOKEN from GitHub Actions secrets. Crowdin and PR actions are pinned to inspected commit revisions. Repository workflow PR creation is enabled. Local verification: actionlint, configuration and existing locale path checks, and git diff --check passed.

Related to #86. Home display label extraction is being handled separately.
