### PR TITLE
Fix release verification, enable Polish, and sync 1.9.0 metadata

### DIFF
--- a/.github/workflows/crowdin-language.yml
+++ b/.github/workflows/crowdin-language.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   add-language:
-    if: github.repository == 'AlanHuang99/Voyager' && github.ref == 'refs/heads/codex/sync-fdroid-1.9.0'
+    if: github.repository == 'AlanHuang99/Voyager' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/crowdin-language.yml
+++ b/.github/workflows/crowdin-language.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   add-language:
-    if: github.repository == 'AlanHuang99/Voyager' && github.ref == 'refs/heads/master'
+    if: github.repository == 'AlanHuang99/Voyager' && github.ref == 'refs/heads/codex/sync-fdroid-1.9.0'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,9 +119,15 @@ jobs:
           expected_cert="$(sed -n 's/^AllowedAPKSigningKeys: //p' metadata/com.voyagerfiles.yml)"
           test -n "$expected_cert"
           for apk in app/build/outputs/apk/release/*.apk; do
-            "$build_tools/apksigner" verify --print-certs "$apk" > "$RUNNER_TEMP/apk-certificate.txt"
-            grep -Fx "Signer #1 certificate SHA-256 digest: $expected_cert" "$RUNNER_TEMP/apk-certificate.txt"
+            echo "Verifying $apk with $build_tools"
+            "$build_tools/apksigner" verify --print-certs "$apk" | tee "$RUNNER_TEMP/apk-certificate.txt"
+            actual_certs="$(sed -nE 's/^Signer .* certificate SHA-256 digest: ([0-9a-fA-F]{64})$/\1/p' "$RUNNER_TEMP/apk-certificate.txt" | tr '[:upper:]' '[:lower:]' | sort -u)"
+            if [ "$actual_certs" != "$expected_cert" ]; then
+              echo "::error::APK signing certificates do not match AllowedAPKSigningKeys."
+              exit 1
+            fi
             "$build_tools/aapt2" dump badging "$apk" > "$RUNNER_TEMP/apk-badging.txt"
+            head -n 1 "$RUNNER_TEMP/apk-badging.txt"
             grep -F "package: name='com.voyagerfiles' versionCode='$RELEASE_VERSION_CODE' versionName='$RELEASE_VERSION_NAME'" "$RUNNER_TEMP/apk-badging.txt"
           done
 

--- a/metadata/com.voyagerfiles.yml
+++ b/metadata/com.voyagerfiles.yml
@@ -110,9 +110,23 @@ Builds:
     gradleprops:
       - voyager.enableAbiSplits=false
 
+  - versionName: 1.9.0
+    versionCode: 17
+    commit: cdc901d063528f3957a0e90d9267215021337b7a
+    subdir: app
+    sudo:
+      - export CPUS_MAX=16
+      - export CPUS=$(getconf _NPROCESSORS_ONLN)
+      - for (( c=$CPUS_MAX; c<$CPUS; c++ )) ; do echo 0 > /sys/devices/system/cpu/cpu$c/online
+        ; done
+    gradle:
+      - yes
+    gradleprops:
+      - voyager.enableAbiSplits=false
+
 AllowedAPKSigningKeys: db496277d456751abe8ca6405026337c81a561a134e38d49c8e21fb8f036badf
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
-CurrentVersion: 1.8.0
-CurrentVersionCode: 16
+CurrentVersion: 1.9.0
+CurrentVersionCode: 17

--- a/scripts/add_crowdin_language.py
+++ b/scripts/add_crowdin_language.py
@@ -53,7 +53,19 @@ def main() -> None:
             with urlopen(req, timeout=30) as response:
                 return json.load(response)
         except HTTPError as error:
-            raise RuntimeError(f"Crowdin {method} failed with HTTP {error.code}") from None
+            details = json.loads(error.read(65536))
+            messages = []
+            def collect_messages(value):
+                if isinstance(value, dict):
+                    if isinstance(value.get("message"), str):
+                        messages.append(value["message"].replace(token, "[redacted]"))
+                    for child in value.values():
+                        collect_messages(child)
+                elif isinstance(value, list):
+                    for child in value:
+                        collect_messages(child)
+            collect_messages(details)
+            raise RuntimeError(f"Crowdin {method} failed with HTTP {error.code}: {'; '.join(messages)}") from None
 
     add_language(request, os.environ["CROWDIN_PROJECT_ID"], os.environ["CROWDIN_LANGUAGE_ID"])
 

--- a/scripts/add_crowdin_language.py
+++ b/scripts/add_crowdin_language.py
@@ -1,7 +1,7 @@
 """Purpose: enable one requested Crowdin target language without removing existing languages.
 Inputs: project ID, language ID, and CROWDIN_PERSONAL_TOKEN from the environment.
 Outputs: an updated Crowdin target-language list, verified by a second read.
-Notes: uses a conditional JSON Patch; never prints credentials or response bodies.
+Notes: merges the current target list and verifies the result; never prints credentials or full response bodies.
 """
 
 import json
@@ -30,8 +30,8 @@ def add_language(request, project_id: str, language_id: str) -> None:
         return
     if project["sourceLanguageId"] == language_id:
         raise ValueError("The source language cannot be added as a target")
+    # Crowdin's test operation compares internal numeric IDs with the public language codes and rejects an otherwise unchanged list.
     request("PATCH", project_path, [
-        {"op": "test", "path": "/targetLanguageIds", "value": existing},
         {"op": "replace", "path": "/targetLanguageIds", "value": [*existing, language_id]},
     ])
     verified = request("GET", project_path)["data"]["targetLanguageIds"]

--- a/scripts/test_add_crowdin_language.py
+++ b/scripts/test_add_crowdin_language.py
@@ -14,7 +14,6 @@ class AddLanguageTest(unittest.TestCase):
         ])
         add_language(request, "927407", "pl")
         self.assertEqual(request.call_args_list[2].args, ("PATCH", "/projects/927407", [
-            {"op": "test", "path": "/targetLanguageIds", "value": ["fr", "zh-CN"]},
             {"op": "replace", "path": "/targetLanguageIds", "value": ["fr", "zh-CN", "pl"]},
         ]))
 

--- a/scripts/test_add_crowdin_language.py
+++ b/scripts/test_add_crowdin_language.py
@@ -1,7 +1,9 @@
+import io
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
+from urllib.error import HTTPError
 
-from add_crowdin_language import add_language
+from add_crowdin_language import add_language, main
 
 
 class AddLanguageTest(unittest.TestCase):
@@ -40,6 +42,19 @@ class AddLanguageTest(unittest.TestCase):
         ])
         with self.assertRaises(RuntimeError):
             add_language(request, "927407", "pl")
+
+    def test_api_validation_error_reports_reason_without_credentials(self):
+        response = io.BytesIO(b'{"error":{"message":"Validation failed: secret-test-token"}}')
+        error = HTTPError("https://api.crowdin.com/api/v2/languages/pl", 400, "Bad Request", {}, response)
+        with patch.dict("os.environ", {
+            "CROWDIN_PERSONAL_TOKEN": "secret-test-token",
+            "CROWDIN_PROJECT_ID": "927407",
+            "CROWDIN_LANGUAGE_ID": "pl",
+        }), patch("add_crowdin_language.urlopen", side_effect=error):
+            with self.assertRaises(RuntimeError) as caught:
+                main()
+        self.assertIn("HTTP 400: Validation failed: [redacted]", str(caught.exception))
+        self.assertNotIn("secret-test-token", str(caught.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Enable requested Crowdin languages using its supported project update operation, preserving and verifying existing targets. Include redacted API error details when a request fails. Polish was enabled and verified through the workflow and its public translation page.

Pin F-Droid metadata for version 1.9.0 (17) to release source cdc901d063528f3957a0e90d9267215021337b7a. Accept numbered and SDK-range signer labels in APK verification, require every signer to match the pinned certificate, and print public certificate diagnostics before publication. The initial signed build passed but its identity check stopped publication without diagnostic output; retry the existing tag after this workflow update.

Validation: Crowdin helper tests pass; live Polish enablement succeeded; clean F-Droid configuration build passed; actionlint passed; certificate parsing passed six checks covering the previous published APK, SDK-range labels, missing signatures, wrong keys, and additional signers. Application source is unchanged from the tested release tag.