### PR TITLE
Fix APK certificate parsing for Android Build Tools 37

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
           for apk in app/build/outputs/apk/release/*.apk; do
             echo "Verifying $apk with $build_tools"
             "$build_tools/apksigner" verify --print-certs "$apk" | tee "$RUNNER_TEMP/apk-certificate.txt"
-            actual_certs="$(sed -nE 's/^Signer .* certificate SHA-256 digest: ([0-9a-fA-F]{64})$/\1/p' "$RUNNER_TEMP/apk-certificate.txt" | tr '[:upper:]' '[:lower:]' | sort -u)"
+            actual_certs="$(sed -nE 's/^(Signer[^:]*|V[0-9]+ Signer[^:]*):? certificate SHA-256 digest: ([0-9a-fA-F]{64})$/\2/p' "$RUNNER_TEMP/apk-certificate.txt" | tr '[:upper:]' '[:lower:]' | sort -u)"
             if [ "$actual_certs" != "$expected_cert" ]; then
               echo "::error::APK signing certificates do not match AllowedAPKSigningKeys."
               exit 1


### PR DESCRIPTION
Android Build Tools 37 reports the valid release certificate with a `V2 Signer:` prefix. The publication guard rejected this output even though its fingerprint matched the pinned key. Accept scheme-prefixed, numbered, and SDK-range signer labels while still requiring every extracted certificate to match the pinned key.

Validation: actionlint passed; eight parser checks passed, including the actual failing CI output, the previous published APK, SDK-range labels, and rejection of missing, unexpected, or additional signing keys. Signed build, unit tests, and lint passed before the parser failure. Application source and release tag are unchanged.
